### PR TITLE
插件卡片说出平台一直在提供的那些事实

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,8 @@
 		"./tokens": "./src/tokens.ts",
 		"./activity": "./src/activity.ts",
 		"./trajectory-view": "./src/trajectory-view.ts",
-		"./schedule": "./src/config/schedule.ts"
+		"./schedule": "./src/config/schedule.ts",
+		"./install-record": "./src/plugins/install-record.ts"
 	},
 	"scripts": {
 		"build": "tsc -p tsconfig.json",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,6 +101,7 @@ export {
 	installEntry,
 	uninstallEntry,
 	type BundleKind,
+	type ClientId,
 	type Installed,
 	type Registry,
 	type RegistryEntry,
@@ -115,6 +116,12 @@ export {
 	type PluginInterface,
 	type PluginManifest,
 } from "./plugins/loader.ts";
+/*
+ * `isOutdated` is also published as `@lyra/core/install-record`, and the renderer must use that one.
+ * Importing a *value* from this index pulls the whole of it into a browser bundle, which reaches
+ * `node:fs` and blanks the window. The type is free either way.
+ */
+export { isOutdated, readInstalls, type InstallRecord } from "./plugins/installs.ts";
 export {
 	buildIndex,
 	indexStats,

--- a/packages/core/src/plugins/install-record.ts
+++ b/packages/core/src/plugins/install-record.ts
@@ -1,0 +1,63 @@
+/**
+ * What was installed, and how to tell whether it has since been superseded.
+ *
+ * Split from `installs.ts`, which reads and writes the ledger, because this half has to run in the
+ * renderer. The two facts being compared meet there and nowhere else: what is on disk comes from
+ * the main process's scan, what is on offer comes from a registry the window fetched itself. A
+ * renderer that imported the reading half would pull `node:fs` into a browser bundle and blank the
+ * window on the first import — see the note in AGENTS.md about sub-entries.
+ *
+ * So: no imports, no bindings, nothing but a type and a comparison.
+ */
+
+/** What was installed, as it was described at the moment it was installed. */
+export interface InstallRecord {
+	/** The registry entry's id, which is also the directory name it was installed as. */
+	id: string;
+	/** The version the registry advertised. Often absent or meaningless — see `isOutdated`. */
+	version?: string;
+	/** The upstream commit the archive was built from. The reliable one. */
+	commit?: string;
+	/** Hash of the archive that was downloaded, when it arrived as one rather than as a clone. */
+	sha256?: string;
+	/** Which registry it came from, for the rare case of two offering the same id. */
+	from?: string;
+	installedAt: string;
+}
+
+/**
+ * Whether what is installed is behind what the registry now offers.
+ *
+ * Three comparisons, in descending order of how much they can be trusted, and **silence when none
+ * of them applies**. Claiming an update that is not there is worse than missing one: it puts a
+ * badge on a card that pressing the button beside it cannot clear, because there was nothing to
+ * install and the next scan will say the same thing again.
+ *
+ *   - `commit` — resolved by the platform against the upstream ref at build time. If both sides
+ *     have one and they differ, something upstream genuinely moved.
+ *   - `sha256` — of the built archive. It identifies a build rather than a content, since gzip
+ *     output is runtime-dependent, so it can say "not the same build" and never "same content".
+ *   - `version` — last, because most of this catalogue has no real one. `waza` publishes
+ *     `0.0.0-30bf9a1`, derived from a commit, and `anthropic-skills` publishes `0.0.0`: the first
+ *     differs whenever the commit moves and the second never differs at all.
+ *
+ * Compared for inequality only, never for order. `2026.7.4` and `0.3.7` are both live in this
+ * catalogue and there is no ordering that reads both correctly — and "different" is the whole
+ * question anyway, since a registry serving an older build is still serving what it now offers.
+ */
+export function isOutdated(
+	record: InstallRecord | undefined | null,
+	offered: { commit?: string; sha256?: string; version?: string } | null | undefined,
+): boolean {
+	if (!record || !offered) return false;
+	if (record.commit && offered.commit) return record.commit !== offered.commit;
+	if (record.sha256 && offered.sha256) return record.sha256 !== offered.sha256;
+	if (record.version && offered.version) return record.version !== offered.version;
+	/*
+	 * Nothing comparable on both sides, so nothing is claimed.
+	 *
+	 * Two populations land here and both must stay quiet: bundles installed before the ledger
+	 * existed, which have no record at all, and registries that publish none of the three fields.
+	 */
+	return false;
+}

--- a/packages/core/src/plugins/installs.ts
+++ b/packages/core/src/plugins/installs.ts
@@ -1,0 +1,82 @@
+/**
+ * What a bundle was when it was installed, so that "is there a newer one" can be asked at all.
+ *
+ * Installing used to leave no trace of where the files came from. The directory holds a manifest,
+ * and a manifest holds whatever the author wrote in it — which for most of the catalogue is either
+ * nothing or a version that never moves. So the app could show a bundle beside a registry entry
+ * offering the same bundle and have no way to tell whether they were the same bundle.
+ *
+ * This is deliberately a ledger rather than a file inside each directory. A skill collection has no
+ * directory of its own — `moveInto` flattens its skills in among the loose ones — so a per-bundle
+ * file would work for two of the three kinds and need a second mechanism for the third. One file
+ * that answers for all three is the smaller thing.
+ *
+ * The ledger is not authority. What is on disk is: an entry here whose directory has been deleted
+ * by hand is stale, and every reader joins on what the scan found rather than trusting this. It
+ * only ever adds facts to bundles that are already there.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { lyraHome } from "../session/store.ts";
+import type { InstallRecord } from "./install-record.ts";
+
+/*
+ * The record itself and the comparison live next door, in a file that imports nothing.
+ *
+ * They have to: the renderer is where an installed bundle meets the entry a registry is offering,
+ * so that is where `isOutdated` runs, and anything reachable from a browser bundle may not touch
+ * `node:fs`. Re-exported here so that code with a filesystem gets both halves from one import.
+ */
+export { isOutdated, type InstallRecord } from "./install-record.ts";
+
+function ledgerPath(): string {
+	return join(lyraHome(), "installs.json");
+}
+
+/**
+ * Every install we have a record of, keyed by id.
+ *
+ * A missing or corrupt file is an empty ledger rather than an error. Nothing here is load-bearing:
+ * without it every bundle simply reports an unknown origin, which is the same state as a bundle
+ * installed before this existed, and the plugins page has to handle that anyway.
+ */
+export async function readInstalls(): Promise<Record<string, InstallRecord>> {
+	const raw = await readFile(ledgerPath(), "utf8").catch(() => null);
+	if (!raw) return {};
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+		return parsed as Record<string, InstallRecord>;
+	} catch {
+		return {};
+	}
+}
+
+/**
+ * Write one record, leaving the rest alone.
+ *
+ * Read-modify-write, which is safe here because installs are driven by a person clicking a button
+ * in one window: two of them landing between the read and the write would need two clicks inside
+ * the same few milliseconds. Making it atomic would mean a lock file to clean up after crashes,
+ * and the loss in the case it protects against is one bundle reporting an unknown origin.
+ */
+export async function recordInstall(record: InstallRecord): Promise<void> {
+	const all = await readInstalls();
+	all[record.id] = record;
+	await save(all);
+}
+
+/** Forget a bundle, because it is no longer on disk. */
+export async function forgetInstall(id: string): Promise<void> {
+	const all = await readInstalls();
+	if (!(id in all)) return;
+	delete all[id];
+	await save(all);
+}
+
+async function save(all: Record<string, InstallRecord>): Promise<void> {
+	await mkdir(lyraHome(), { recursive: true });
+	await writeFile(ledgerPath(), `${JSON.stringify(all, null, "\t")}\n`, "utf8");
+}

--- a/packages/core/src/plugins/loader.ts
+++ b/packages/core/src/plugins/loader.ts
@@ -34,6 +34,7 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { basename, isAbsolute, join, relative as relativePath, resolve } from "node:path";
 import type { McpServerConfig } from "../mcp/client.ts";
 import { loadSkills, type Skill } from "../skills/loader.ts";
+import { readInstalls, type InstallRecord } from "./installs.ts";
 
 export interface PluginInterface {
 	displayName?: string;
@@ -71,6 +72,14 @@ export interface Plugin {
 	source: "workspace" | "user";
 	skills: Skill[];
 	enabled: boolean;
+	/**
+	 * What the registry said this was when it was installed, when it came from one.
+	 *
+	 * Absent for a directory somebody put here themselves, and for anything installed before the
+	 * ledger existed. Both mean "no idea where this came from", which is why nothing may treat its
+	 * absence as evidence of anything — see `isOutdated`.
+	 */
+	origin?: InstallRecord;
 	/** Populated when the bundle is present but unusable. */
 	error?: string;
 }
@@ -91,6 +100,8 @@ export interface McpBundle {
 	source: "workspace" | "user";
 	/** What its `.mcp.json` declares, ready to be merged into settings. */
 	servers: McpServerConfig[];
+	/** Where it came from, when it came from a registry. See `Plugin.origin`. */
+	origin?: InstallRecord;
 }
 
 export interface PluginDiagnostic {
@@ -119,6 +130,15 @@ export async function loadPlugins(
 	const mcpBundles: McpBundle[] = [];
 	const diagnostics: PluginDiagnostic[] = [];
 	const seen = new Set<string>();
+	/*
+	 * Read once for the whole scan, and joined on rather than trusted.
+	 *
+	 * The ledger says what was installed; this loop says what is there. A bundle whose directory was
+	 * deleted by hand never reaches the join, so a stale record is invisible rather than wrong — and
+	 * a bundle the user dropped in themselves has no record at all, which is the honest answer to
+	 * "where did this come from" and the reason nothing may be inferred from its absence.
+	 */
+	const installs = await readInstalls();
 
 	for (const { dir, source } of sources) {
 		const entries = await readdir(dir, { withFileTypes: true }).catch(() => null);
@@ -187,6 +207,7 @@ export async function loadPlugins(
 					dir: pluginDir,
 					manifest,
 					source,
+					origin: installs[id],
 					// `id`, so that what stamps a row and what looks the row up are the same string.
 					servers: read.servers.map((server) => ({
 						...server,
@@ -201,6 +222,7 @@ export async function loadPlugins(
 				dir: pluginDir,
 				manifest,
 				source,
+				origin: installs[id],
 				// Tag skills so the UI can show which plugin brought them in.
 				skills: read.skills.map((skill) => ({ ...skill, pluginId: id })),
 				/*

--- a/packages/core/src/plugins/registry.ts
+++ b/packages/core/src/plugins/registry.ts
@@ -21,6 +21,7 @@ import type { BundleKind, RegistryEntry } from "@lyra/registry-shared";
 import type { McpServerConfig } from "../mcp/client.ts";
 import { lyraHome } from "../session/store.ts";
 import { fetchBundle } from "./fetch-bundle.ts";
+import { forgetInstall, recordInstall } from "./installs.ts";
 import { inspectBundle } from "./loader.ts";
 
 /*
@@ -34,7 +35,10 @@ import { inspectBundle } from "./loader.ts";
  * Re-exported rather than replaced at every call site: the renderer imports these from `@lyra/core`
  * in a dozen places, and moving a type is not a reason to touch a dozen files.
  */
-export type { BundleKind, RegistryEntry } from "@lyra/registry-shared";
+// `ClientId` too: the desktop package depends on core alone, and a card that shows which agents a
+// bundle installs into needs the type. Adding a second dependency to reach one alias would be a
+// wider change than re-exporting it beside the entry type it is a field of.
+export type { BundleKind, ClientId, RegistryEntry } from "@lyra/registry-shared";
 export { normalise } from "@lyra/registry-shared";
 
 /** How long a registry has to answer before we give up on it. */
@@ -110,28 +114,40 @@ export interface Installed {
  * what gets kept; the rest, including the `.git` that would otherwise make a subdirectory look
  * like a checkout of the whole collection, is thrown away.
  */
-export async function installEntry(entry: RegistryEntry, registryName?: string): Promise<Installed> {
+export async function installEntry(entry: RegistryEntry, registryName?: string, replace = false): Promise<Installed> {
 	// Shared with the platform, so that a path it accepted when building an archive is the same path
 	// this refuses to clone into. Two implementations of "cannot climb out" is one too many.
 	const inner = normalisePath(entry.path);
 	if (inner === null) throw new Error(`插件路径不合法：${entry.path}`);
 
-	for (const kind of ["plugin", "mcp"] as const) {
-		const root = bundleRoot(kind);
-		if ((await readdir(root).catch((): string[] => [])).includes(entry.id)) {
-			throw new Error(`已经装过 ${entry.id} 了`);
-		}
-	}
 	/*
-	 * And a collection, which has no directory to look for — only its prefix among the loose skills.
+	 * `replace` is what an update is, and it is safe for the same reason a first install is.
 	 *
-	 * Without this the same collection could be installed twice: the second run overwrites every
-	 * skill it still ships and silently leaves behind the ones it has since dropped, which is a
-	 * worse state than either version.
+	 * Everything lands in staging and is inspected there; the target directory is not touched until
+	 * a complete, verified bundle is sitting beside it. So a failed update — a dead network, a
+	 * corrupt archive, a repository that has stopped being a plugin — leaves what is installed
+	 * exactly as it was. The alternative people usually write, uninstall-then-install, has a window
+	 * in the middle where the user has neither version.
 	 */
-	if (entry.kind === "skill") {
-		const loose = await readdir(bundleRoot("skill")).catch((): string[] => []);
-		if (loose.some((name) => name.startsWith(`${entry.id}-`))) throw new Error(`已经装过 ${entry.id} 了`);
+	if (!replace) {
+		for (const kind of ["plugin", "mcp"] as const) {
+			const root = bundleRoot(kind);
+			if ((await readdir(root).catch((): string[] => [])).includes(entry.id)) {
+				throw new Error(`已经装过 ${entry.id} 了`);
+			}
+		}
+		/*
+		 * And a collection, which has no directory to look for — only its prefix among the loose
+		 * skills.
+		 *
+		 * Without this the same collection could be installed twice: the second run overwrites every
+		 * skill it still ships and silently leaves behind the ones it has since dropped, which is a
+		 * worse state than either version.
+		 */
+		if (entry.kind === "skill") {
+			const loose = await readdir(bundleRoot("skill")).catch((): string[] => []);
+			if (loose.some((name) => name.startsWith(`${entry.id}-`))) throw new Error(`已经装过 ${entry.id} 了`);
+		}
 	}
 
 	// Beside the eventual target rather than in the OS temp dir: same filesystem, so the move is a
@@ -171,7 +187,20 @@ export async function installEntry(entry: RegistryEntry, registryName?: string):
 			const skills = await countSkills(source);
 			if (skills === 0) throw new Error("这个目录里没有技能（应当是一层含 SKILL.md 的子目录）");
 			const root = bundleRoot("skill");
+			/*
+			 * Clear the old scatter before laying down the new one.
+			 *
+			 * `moveInto` overwrites each skill it still ships and cannot know about the ones this
+			 * version dropped — those would stay in the skills directory forever, loaded into every
+			 * session, belonging to a version of the collection nobody has any more. A plugin does
+			 * not have this problem because its whole directory is replaced at once.
+			 *
+			 * Done here rather than before the download: by this point the new files are staged and
+			 * verified, so the window in which the collection is half-removed is one rename wide.
+			 */
+			if (replace) await removeCollection(entry.id);
 			await moveInto(source, root, entry.id);
+			await remember(entry, registryName);
 			// `dir` is the directory the skills went into; a collection has no directory of its own.
 			return { dir: root, kind: "skill", servers: [], name: `${entry.name}（${skills} 个技能）` };
 		}
@@ -201,6 +230,7 @@ export async function installEntry(entry: RegistryEntry, registryName?: string):
 		 */
 		await rm(join(source, ".git"), { recursive: true, force: true });
 		await rename(source, target);
+		await remember(entry, registryName);
 
 		return {
 			dir: target,
@@ -222,6 +252,23 @@ export async function installEntry(entry: RegistryEntry, registryName?: string):
 }
 
 /**
+ * Note what this was, so a later visit can tell it apart from what the registry now offers.
+ *
+ * Failing to write the ledger must not fail the install: the files are already in place and the
+ * bundle works. What is lost is the update badge, which is worth less than the bundle.
+ */
+async function remember(entry: RegistryEntry, registryName?: string): Promise<void> {
+	await recordInstall({
+		id: entry.id,
+		version: entry.version,
+		commit: entry.commit,
+		sha256: entry.sha256,
+		from: registryName,
+		installedAt: new Date().toISOString(),
+	}).catch(() => undefined);
+}
+
+/**
  * Drop an installed bundle, whichever of the two directories it lives in.
  *
  * Both are cleared rather than asking the caller which kind it was: an id is unique across the
@@ -234,16 +281,26 @@ export async function uninstallEntry(id: string): Promise<void> {
 	await rm(join(bundleRoot("plugin"), id), { recursive: true, force: true });
 	await rm(join(bundleRoot("mcp"), id), { recursive: true, force: true });
 
-	/*
-	 * And the skills a collection scattered, which have no directory of their own to remove.
-	 *
-	 * `moveInto` flattened them in among the loose skills with an `<id>-` prefix, so this is the
-	 * same rename read backwards. Removing only the two bundle roots left a collection uninstalled
-	 * everywhere except in the agent, which went on loading all of its skills.
-	 *
-	 * The prefix has to be followed by something: a skill genuinely named `waza` is not one of
-	 * Waza's, and dropping it would be deleting a directory the user put there themselves.
-	 */
+	// And a collection's skills, which are not under either root. Removing only the two left a
+	// collection uninstalled everywhere except in the agent, which went on loading all of them.
+	await removeCollection(id);
+
+	// Last, and allowed to fail: a stale ledger entry is harmless because every reader joins it
+	// against what the scan actually found, while a bundle whose files are gone is uninstalled.
+	await forgetInstall(id).catch(() => undefined);
+}
+
+/**
+ * Remove the skills a collection scattered, which have no directory of their own.
+ *
+ * `moveInto` flattened them in among the loose skills with an `<id>-` prefix, so this is the same
+ * rename read backwards. Shared with the replace path in `installEntry`, because an update that
+ * left the previous version's dropped skills behind would be the same bug in a different place.
+ *
+ * The prefix has to be followed by something: a skill genuinely named `waza` is not one of Waza's,
+ * and removing it would be deleting a directory the user put there themselves.
+ */
+async function removeCollection(id: string): Promise<void> {
 	const skills = bundleRoot("skill");
 	for (const entry of await readdir(skills, { withFileTypes: true }).catch((): Dirent[] => [])) {
 		if (entry.isDirectory() && entry.name.startsWith(`${id}-`)) {

--- a/packages/core/test/install-record.test.ts
+++ b/packages/core/test/install-record.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Whether a bundle is behind what its registry now offers.
+ *
+ * The interesting cases are all refusals. An update badge that cannot be cleared is worse than no
+ * badge at all: pressing the button beside it reinstalls the same bytes and the badge comes back,
+ * so the page is now lying about something the user cannot fix.
+ *
+ * The version strings here are the real ones from the live catalogue, because they are the reason
+ * the comparison is ordered the way it is — `0.0.0` and `0.0.0-30bf9a1` are what most of it
+ * actually publishes.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isOutdated, type InstallRecord } from "../src/plugins/install-record.ts";
+
+function installed(fields: Partial<InstallRecord> = {}): InstallRecord {
+	return { id: "waza", installedAt: "2026-08-01T00:00:00.000Z", ...fields };
+}
+
+test("a moved commit is an update", () => {
+	assert.equal(isOutdated(installed({ commit: "aaa" }), { commit: "bbb" }), true);
+});
+
+test("the same commit is not", () => {
+	assert.equal(isOutdated(installed({ commit: "aaa" }), { commit: "aaa" }), false);
+});
+
+test("the commit decides even when the version disagrees with it", () => {
+	// A registry that rebuilt the same commit and stamped a new version string has not moved.
+	assert.equal(isOutdated(installed({ commit: "aaa", version: "1.0.0" }), { commit: "aaa", version: "1.0.1" }), false);
+});
+
+test("the archive hash is used when there is no commit on both sides", () => {
+	assert.equal(isOutdated(installed({ sha256: "aa" }), { sha256: "bb" }), true);
+	assert.equal(isOutdated(installed({ sha256: "aa" }), { sha256: "aa" }), false);
+});
+
+test("versions are compared only when neither better signal is available", () => {
+	assert.equal(isOutdated(installed({ version: "0.3.7" }), { version: "0.3.8" }), true);
+	assert.equal(isOutdated(installed({ version: "0.3.7" }), { version: "0.3.7" }), false);
+});
+
+test("a version that never moves never claims an update", () => {
+	// `anthropic-skills` publishes 0.0.0 and always has. Comparing for order would be no better;
+	// there is simply no information in the field.
+	assert.equal(isOutdated(installed({ version: "0.0.0" }), { version: "0.0.0" }), false);
+});
+
+test("a registry offering an older build still counts as different", () => {
+	/*
+	 * Deliberate: the question is "does what you have match what is on offer", not "is yours
+	 * older". A registry that rolled back is offering the rollback, and no ordering could answer
+	 * this anyway — `2026.7.4` and `0.3.7` are both live in this catalogue.
+	 */
+	assert.equal(isOutdated(installed({ version: "0.3.8" }), { version: "0.3.7" }), true);
+});
+
+test("a bundle with no record claims nothing", () => {
+	// Anything installed before the ledger existed, and anything the user dropped in themselves.
+	assert.equal(isOutdated(undefined, { commit: "bbb", version: "9.9.9" }), false);
+});
+
+test("an entry with nothing comparable claims nothing", () => {
+	assert.equal(isOutdated(installed({ commit: "aaa" }), null), false);
+	assert.equal(isOutdated(installed({ commit: "aaa" }), {}), false);
+	assert.equal(isOutdated(installed(), { commit: "bbb" }), false);
+});
+
+test("one side having a field the other lacks falls through rather than guessing", () => {
+	// Installed knows its commit, the registry only publishes a version: comparing those two is
+	// not a comparison. Falls to `version`, which the record does not have, so nothing is claimed.
+	assert.equal(isOutdated(installed({ commit: "aaa" }), { version: "1.0.0" }), false);
+	// And the reverse, which is what a registry that started publishing commits looks like on the
+	// first visit after an upgrade. Falls to version, where both sides agree.
+	assert.equal(isOutdated(installed({ version: "1.0.0" }), { commit: "bbb", version: "1.0.0" }), false);
+});

--- a/packages/desktop/electron/ipc-types.ts
+++ b/packages/desktop/electron/ipc-types.ts
@@ -287,9 +287,18 @@ export interface LyraApi {
 		 * a plugin that holds nothing but a `.mcp.json` and what you have installed is an MCP
 		 * server, whose servers are now in settings switched off, waiting to be turned on.
 		 */
+		/**
+		 * `replace` turns the same call into an update.
+		 *
+		 * It skips the "already installed" check and overwrites what is there — safely, because the
+		 * new bundle is downloaded and inspected in a staging directory first, so a failed update
+		 * leaves the working copy untouched. Uninstall-then-install would not: it has a window in
+		 * the middle where the user has neither version.
+		 */
 		installFromRegistry(
 			entry: RegistryEntry,
 			registryName?: string,
+			replace?: boolean,
 		): Promise<{ ok: true; dir: string; kind: BundleKind; servers: number } | { ok: false; message: string }>;
 		uninstall(id: string): Promise<void>;
 	};

--- a/packages/desktop/electron/ipc/plugins.ts
+++ b/packages/desktop/electron/ipc/plugins.ts
@@ -69,9 +69,11 @@ export function registerPluginsIpc({ settings, saveSettings }: PluginsIpcDeps): 
 	 * They arrive switched off — installing is not the same as trusting, and a server is a command
 	 * that runs on this machine with this user's permissions.
 	 */
-	ipcMain.handle("registry:install", async (_event, entry: RegistryEntry, registryName?: string) => {
+	// `replace` is an update: same call, but the "already installed" check is skipped and the old
+	// files are replaced only once the new ones are staged and verified. See `installEntry`.
+	ipcMain.handle("registry:install", async (_event, entry: RegistryEntry, registryName?: string, replace?: boolean) => {
 		try {
-			const installed = await installEntry(entry, registryName);
+			const installed = await installEntry(entry, registryName, replace);
 			const next = settingsAfterInstall(settings(), entry.id, installed);
 			if (next) await saveSettings(next);
 			return { ok: true as const, dir: installed.dir, kind: installed.kind, servers: installed.servers.length };

--- a/packages/desktop/electron/preload.ts
+++ b/packages/desktop/electron/preload.ts
@@ -182,7 +182,8 @@ const api: LyraApi = {
 		fetchRegistry: (url, force) => ipcRenderer.invoke("registry:fetch", url, force),
 		icon: (url) => ipcRenderer.invoke("registry:icon", url),
 		icons: (urls) => ipcRenderer.invoke("registry:icons", urls),
-		installFromRegistry: (entry, registryName) => ipcRenderer.invoke("registry:install", entry, registryName),
+		installFromRegistry: (entry, registryName, replace) =>
+			ipcRenderer.invoke("registry:install", entry, registryName, replace),
 		uninstall: (id) => ipcRenderer.invoke("registry:uninstall", id),
 	},
 	

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -46,6 +46,7 @@
 		"@fontsource-variable/jetbrains-mono": "^5.3.0",
 		"@lezer/highlight": "^1.2.3",
 		"@lyra/core": "workspace:*",
+		"@lyra/registry-shared": "workspace:*",
 		"@modelcontextprotocol/sdk": "1.30.0",
 		"@xterm/addon-fit": "0.11.0-beta.126",
 		"@xterm/xterm": "5.6.0-beta.126",

--- a/packages/desktop/src/components/PluginsView.tsx
+++ b/packages/desktop/src/components/PluginsView.tsx
@@ -32,7 +32,8 @@ import { PluginIcon, SkillMark } from "./settings/PluginIcon.tsx";
 import { CatalogCard } from "./plugins/CatalogCard.tsx";
 import { PluginDetail } from "./plugins/PluginDetail.tsx";
 import { RegistrySources } from "./plugins/RegistrySources.tsx";
-import { groupByCategory, isEnabled, isInstalled, UNFILED, useCatalog } from "./plugins/useCatalog.ts";
+import { settingsAfterToggle } from "./plugins/toggle.ts";
+import { groupByCategory, isEnabled, isInstalled, UNFILED, useCatalog, type CatalogItem } from "./plugins/useCatalog.ts";
 import { RollingText } from "./RollingText.tsx";
 
 /**
@@ -59,6 +60,9 @@ export function PluginsView() {
 	const setSettingsSection = useApp((s) => s.setSettingsSection);
 	const setComposerDraft = useApp((s) => s.setComposerDraft);
 	const newSession = useApp((s) => s.newSession);
+
+	const settings = useApp((s) => s.settings);
+	const saveSettings = useApp((s) => s.saveSettings);
 
 	const catalog = useCatalog();
 	const [tab, setTab] = useState<Tab>("plugins");
@@ -98,6 +102,29 @@ export function PluginsView() {
 		void newSession();
 		setComposerDraft(prompt);
 		setView("chat");
+	};
+
+	/**
+	 * Switch a plugin on or off from its card, without going to 设置 first.
+	 *
+	 * The rule is `settingsAfterToggle`, shared with the settings list — the wildcard case is not
+	 * obvious and two copies of it would be right in one place only.
+	 *
+	 * Only a plugin has one switch: an MCP bundle has one per server it brought, which is a
+	 * different control on a different page, and a collection has none at all. `CatalogCard` draws
+	 * nothing when this returns without acting.
+	 */
+	const toggle = (item: CatalogItem, enabled: boolean) => {
+		const plugin = item.installed;
+		if (!plugin || !settings) return;
+		void saveSettings(
+			settingsAfterToggle(
+				settings,
+				plugin,
+				enabled,
+				catalog.items.flatMap((entry) => (entry.installed ? [entry.installed] : [])),
+			),
+		);
 	};
 
 	// Whichever kind this tab is about. Everything below — the counts, the two scopes, the
@@ -392,6 +419,7 @@ export function PluginsView() {
 													<CatalogCard
 														item={item}
 														onOpen={() => setOpenKey(item.key)}
+											onToggle={(enabled) => toggle(item, enabled)}
 														onChanged={() => {
 															setFailure(null);
 															catalog.refresh();
@@ -438,6 +466,7 @@ export function PluginsView() {
 												<CatalogCard
 													item={item}
 													onOpen={() => setOpenKey(item.key)}
+											onToggle={(enabled) => toggle(item, enabled)}
 													onChanged={() => {
 														setFailure(null);
 														catalog.refresh();

--- a/packages/desktop/src/components/plugins/CardMeta.tsx
+++ b/packages/desktop/src/components/plugins/CardMeta.tsx
@@ -1,0 +1,132 @@
+/**
+ * Everything a card says about a bundle other than its name and what it does.
+ *
+ * Two lines with different jobs. The one under the title is *identity* — which shelf it came from,
+ * which version, what it is called on disk, who wrote it — and it is the line you read when you
+ * are deciding whether this is the thing you were looking for. The one at the bottom is *size and
+ * reach*: how many skills, how many servers, how many people have it, which agents it installs
+ * into. That one you read when comparing two entries that both look right.
+ *
+ * Every field is optional and an absent one is left out rather than dashed. A bundle sitting in
+ * `~/.lyra/plugins` has no author, no version beyond what its own manifest claims and no download
+ * count, and printing "—" three times to say so fills the line with nothing.
+ *
+ * None of this is new information. The platform has published all of it since it existed and the
+ * site has drawn it on its own cards the whole time; the desktop card showed a name and a sentence,
+ * so two views of one catalogue disagreed about how much was known.
+ */
+
+/*
+ * The labels come from the contract package, not from a copy kept here.
+ *
+ * `@lyra/registry-shared` is types and pure functions by construction — no filesystem, no network,
+ * no DOM — which is what makes it importable from a renderer where `@lyra/core`'s index is not. A
+ * second table of these names would be a second thing to update when a client is added, and the
+ * one that drifts is always the copy nobody compiles against the platform.
+ */
+import { CLIENT_LABEL } from "@lyra/registry-shared";
+
+import type { CatalogItem } from "./catalog.ts";
+
+/**
+ * The identity line: 公开 · v0.3.7 · agent-browser-cli · sleepinginsummer
+ *
+ * The id is in the monospace face because it is a string you type — it is the directory the bundle
+ * installs as and the argument every command takes — while the name beside it is prose.
+ */
+export function IdentityLine({ item }: { item: CatalogItem }): React.ReactNode {
+	const parts: React.ReactNode[] = [];
+
+	// Which half of the catalogue it belongs to. The card can be reached from either scope, and the
+	// distinction survives being installed: something from a registry stays "公开" once you have it.
+	parts.push(<span key="scope">{item.entry ? "公开" : "个人"}</span>);
+	if (item.version) {
+		parts.push(
+			<span key="version" className="tabular-nums">
+				{/* Prefixed here rather than stored with the `v`, because the version is compared as a
+				    string elsewhere and a display prefix in the data is a bug waiting for that. */}
+				v{item.version}
+			</span>,
+		);
+	}
+	/*
+	 * The id resists shrinking four times harder than the author does.
+	 *
+	 * When the line runs out of room both would otherwise truncate together, each losing half of
+	 * what is missing — measured on a 360px card: `agent-browser-cli` and `sleepinginsummer` both
+	 * ellipsised, and neither was readable. They are not worth the same. The id is a string you
+	 * type: it is the directory on disk and the argument every command takes, so half of it is
+	 * useless. An author's name half-shown is still recognisable, and is not something you retype.
+	 */
+	parts.push(
+		<span key="id" className="shrink-[0.25] truncate font-mono">
+			{item.id}
+		</span>,
+	);
+	if (item.author) {
+		parts.push(
+			<span key="author" className="truncate">
+				{item.author}
+			</span>,
+		);
+	}
+
+	return (
+		<div className="mt-1 flex min-w-0 items-center gap-1.5 text-caption text-ink-faint">
+			{parts.map((part, index) => (
+				// The separator belongs to the gap between two parts, so the line never ends on one.
+				<span key={index} className="flex min-w-0 items-center gap-1.5">
+					{index > 0 && <span className="text-ink-faint/50">·</span>}
+					{part}
+				</span>
+			))}
+		</div>
+	);
+}
+
+/**
+ * The footprint line: how much it brings, who can use it, how many took it.
+ *
+ * Skipped entirely when there is nothing to say, rather than rendered as an empty row — a card in a
+ * grid whose neighbours have this line is already taller than one that does not, and an empty
+ * element makes the difference into a ragged gap instead of an honest one.
+ */
+export function FootprintLine({ item }: { item: CatalogItem }): React.ReactNode {
+	const counts: string[] = [];
+	/*
+	 * A collection reports what is on disk, everything else what it holds.
+	 *
+	 * `collected` is the number of this collection's skills found among the loose ones, which is the
+	 * only evidence a collection leaves that it was installed — it has no directory. For a plugin,
+	 * `skillCount` is what the loader counted once it is installed and what the index claimed before.
+	 */
+	const skills = item.collected > 0 ? item.collected : item.skillCount;
+	if (skills) counts.push(`${skills} 个技能`);
+	if (item.serverCount) counts.push(`${item.serverCount} 个服务`);
+
+	const clients = item.clients ?? [];
+	if (counts.length === 0 && clients.length === 0 && !item.downloads) return null;
+
+	return (
+		<div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-caption text-ink-faint">
+			{clients.map((client) => (
+				<span
+					key={client}
+					className="rounded-md border border-line-soft px-1.5 py-px leading-[1.5] text-ink-muted"
+				>
+					{CLIENT_LABEL[client] ?? client}
+				</span>
+			))}
+			{counts.map((count) => (
+				<span key={count} className="tabular-nums">
+					{count}
+				</span>
+			))}
+			{/*
+			 * A popularity signal, not a fact about the bundle — and shown only once it means
+			 * anything. "0 次安装" on a new entry reads as a verdict on it rather than as its age.
+			 */}
+			{(item.downloads ?? 0) > 0 && <span className="tabular-nums">↓ {item.downloads}</span>}
+		</div>
+	);
+}

--- a/packages/desktop/src/components/plugins/CatalogCard.tsx
+++ b/packages/desktop/src/components/plugins/CatalogCard.tsx
@@ -1,36 +1,33 @@
 /**
  * One bundle in the catalogue.
  *
- * A card, not a settings row: a mark, a name, one line about what it does, and nothing else on
- * the surface. Everything that could be done to it lives behind the ⋯, which is what keeps a grid
- * of twenty of these readable — a row with a toggle, a version, a source badge and two links on
- * it is a form, and a page of forms cannot be skimmed. What you already have is said once, in the
- * corner, because that is the only fact you are scanning for.
+ * A card with a border, which it did not used to have: it was a row that grew a background on
+ * hover, and a grid of those reads as a list of links rather than as a shelf of things. The border
+ * is what makes the icon, the name and the lines under it belong to each other — and it is what the
+ * site's own catalogue has always done, so the two views of one registry now agree.
  *
- * The two states have one control each, and it is never the same one:
+ * What it says has grown for a plainer reason: the data was already there. `version`, `author`,
+ * `downloads`, `skillCount` and `clients` have been in every index the platform serves since it
+ * existed, and this card drew a name and a sentence. See `CardMeta` for what the two lines are for.
  *
- *   - not installed — 安装, and only that. It is why the page exists, and it is stated rather
- *     than revealed on hover, because a button you have to find is a button most people do not.
- *   - installed — ⋯, and only that. There is nothing left to press: what remains is trying it,
- *     going to its page, and getting rid of it, none of which is the one obvious next thing.
+ * The actions stay minimal, and the rule is unchanged — one obvious thing, everything else behind
+ * the ⋯:
  *
- * Both used to be on at once, which put an 安装 button beside a ⋯ menu whose first item was also
- * 安装, and then took both away the moment the thing was installed — so the card was busiest when
- * there was one choice and emptiest when there were three.
- *
- * The card body is a button and the action is its sibling laid over its right-hand end. A button
- * inside a button is not a thing the platform has, and wrapping the whole card in one would mean
- * stopping propagation on every control inside it — which works right up until the one that gets
- * added later and does not.
+ *   - not installed — 安装. It is why the page exists, so it is stated rather than revealed on
+ *     hover, because a button you have to find is a button most people do not.
+ *   - installed — the switch, and ⋯ for the rest.
+ *   - installed and superseded — 更新 as well, because that is now the one obvious thing. It is
+ *     the only control here that appears on its own evidence rather than on a state the user set.
  */
 
-import { Check, Download, FolderOpen, Loader2, MoreHorizontal, Play, Settings2, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { ArrowUp, Download, FolderOpen, Loader2, MoreHorizontal, Play, Settings2, Trash2 } from "lucide-react";
 
 import { Confirm } from "../Confirm.tsx";
 import { MenuBody, MenuItem, MenuSeparator, Popover, usePopover } from "../Popover.tsx";
 import { PluginIcon } from "../settings/PluginIcon.tsx";
-import { isEnabled, isInstalled, type CatalogItem } from "./useCatalog.ts";
+import { FootprintLine, IdentityLine } from "./CardMeta.tsx";
+import { isEnabled, isInstalled, type CatalogItem } from "./catalog.ts";
+import { useInstall } from "./useInstall.ts";
 
 export function CatalogCard({
 	item,
@@ -38,6 +35,7 @@ export function CatalogCard({
 	onChanged,
 	onError,
 	onTry,
+	onToggle,
 }: {
 	item: CatalogItem;
 	onOpen: () => void;
@@ -46,22 +44,21 @@ export function CatalogCard({
 	onError: (message: string) => void;
 	/** Starts a conversation with one of the bundle's own example prompts already typed. */
 	onTry: (prompt: string) => void;
+	/**
+	 * Switch it on or off. Absent for kinds that have no single switch.
+	 *
+	 * An MCP bundle has one per server it brought and a collection has none at all — its skills are
+	 * simply among the loose ones once installed. The caller decides, because it is the one holding
+	 * the settings.
+	 */
+	onToggle?: (enabled: boolean) => void;
 }) {
 	const menu = usePopover();
-	const [busy, setBusy] = useState<"install" | "uninstall" | null>(null);
-	/**
-	 * The menu turns into the question rather than opening a second surface over itself.
-	 *
-	 * Stacking a confirmation on top of the menu that raised it means two panels, two shadows and
-	 * a menu still sitting there behind the thing that replaced it. Reset whenever the menu closes,
-	 * so it never reopens on the question nobody answered.
-	 */
-	const [confirming, setConfirming] = useState(false);
+	const act = useInstall(item, onChanged, onError);
 
 	const plugin = item.installed;
 	const bundle = item.bundle;
 	const installed = isInstalled(item);
-	/** Where the directory is, whichever kind it turned out to be. */
 	/*
 	 * Where "打开目录" goes, and the thing whose absence used to hide the whole menu.
 	 *
@@ -81,57 +78,40 @@ export function CatalogCard({
 	const trial = isEnabled(item) ? (manifest?.interface?.defaultPrompt?.[0] ?? null) : null;
 	/** A bundle that lives in the project's own directory is removed by deleting it there. */
 	const removable = installed && (plugin?.source ?? bundle?.source) !== "workspace";
+	/* Only a plugin has one switch. See `onToggle`. */
+	const switchable = onToggle && plugin !== null;
 
 	const close = () => {
 		menu.close();
-		setConfirming(false);
-	};
-
-	const install = async () => {
-		if (!item.entry) return;
-		setBusy("install");
-		const result = await window.lyra.plugins.installFromRegistry(item.entry, item.from ?? undefined);
-		setBusy(null);
-		if (!result.ok) {
-			onError(`${item.name}：${result.message}`);
-			return;
-		}
-		/*
-		 * Said out loud when the index was wrong about what this is.
-		 *
-		 * The kind on the card came from the registry, and the registry is guessing; the clone is
-		 * what settles it. Landing an MCP server in the plugins tab without a word would leave
-		 * someone looking for it under the wrong heading, and its servers arrive switched off, so
-		 * there is a second thing to do that nothing else would mention.
-		 */
-		// `kind` is absent when the main process predates the split — say nothing rather than
-		// claim it turned out to be something else.
-		if (result.kind && result.kind !== item.kind) {
-			onError(
-				result.kind === "mcp"
-					? `${item.name} 其实是一个 MCP 服务，已装到「MCP 服务」下；它的 ${result.servers} 个服务默认关着，去设置 › MCP 里开。`
-					: `${item.name} 其实是一个插件，已装到「插件」下。`,
-			);
-		} else if (result.kind === "mcp") {
-			onError(`${item.name} 已安装，${result.servers} 个服务默认关着——去设置 › MCP 里开。`);
-		}
-		onChanged();
-	};
-
-	const uninstall = async () => {
-		setBusy("uninstall");
-		await window.lyra.plugins.uninstall(item.id);
-		setBusy(null);
-		onChanged();
+		act.setConfirming(false);
 	};
 
 	return (
-		<div className="group/card relative">
+		/*
+		 * The click target is underneath, not around.
+		 *
+		 * A button cannot contain a button, so the switch and the ⋯ cannot sit inside the card's own
+		 * button — they used to be absolutely positioned over its right-hand end, with the text
+		 * column given a fixed right inset to keep clear of them. That inset is a guess about how
+		 * wide the controls are, and it was wrong in both directions at once: too much for a card
+		 * whose only control is a 26px ⋯ (the identity line lost 96px it had no reason to give up,
+		 * and `agent-browser-cli` truncated by nine pixels), and too little for one showing 更新 as
+		 * well as a switch (measured: 118px of controls under a 92px reservation, a 25px overlap).
+		 *
+		 * With the button as a layer behind the content, the controls are ordinary flex children on
+		 * the title row and take exactly the space they take. Nothing is reserved and nothing
+		 * collides. The content layer passes pointer events through to the button; the controls opt
+		 * back in.
+		 */
+		<div className="group/card relative mb-4">
 			<button
 				type="button"
 				onClick={onOpen}
-				className="flex w-full items-start gap-3 rounded-xl p-3 pr-20 text-left transition-colors duration-[var(--ly-t-quick)] hover:bg-card-hover/60"
-			>
+				aria-label={item.name}
+				className="absolute inset-0 rounded-xl border border-line-soft bg-card/40 transition-[background-color,border-color] duration-[var(--ly-t-quick)] hover:border-line hover:bg-card-hover/60"
+			/>
+
+			<div className="pointer-events-none relative flex items-start gap-3 p-3.5">
 				<PluginIcon
 					name={item.name}
 					id={item.id}
@@ -139,94 +119,101 @@ export function CatalogCard({
 					brandColor={item.brandColor}
 					category={item.category}
 					kind={item.kind}
-					size={36}
+					size={38}
 				/>
 
-				<div className="min-w-0 flex-1 pt-0.5">
+				<div className="min-w-0 flex-1">
 					<div className="flex items-center gap-2">
 						<span className="truncate text-label font-medium text-ink">{item.name}</span>
-						{installed && (
-							<span
-								className={`flex shrink-0 items-center gap-1 text-caption ${
-									isEnabled(item) || item.collected > 0 ? "text-ok" : "text-ink-faint"
-								}`}
-							>
-								<Check size={11} strokeWidth={2.4} />
-								{/*
-								 * An MCP bundle starts with every server off, and "已停用" would read as
-								 * something the user did rather than as where it begins.
-								 *
-								 * A skill collection has no switch at all — its skills are simply among the
-								 * loose ones once it is installed. It reported 已停用, naming a state that
-								 * does not exist and cannot be changed. The count is the useful fact and the
-								 * one thing worth checking: it is what the card promised before installing.
-								 */}
-								{item.collected > 0
-									? `${item.collected} 个技能`
-									: isEnabled(item)
-										? "已安装"
-										: item.kind === "mcp"
-											? "未启用"
-											: "已停用"}
+						{item.outdated && (
+							<span className="shrink-0 rounded-md bg-accent/12 px-1.5 py-px text-caption leading-[1.5] text-accent">
+								可更新
 							</span>
 						)}
-					</div>
-					<p className="mt-0.5 line-clamp-2 text-detail leading-relaxed text-ink-muted">
-						{item.description || "（没有描述）"}
-					</p>
-				</div>
-			</button>
-
-			{/*
-			 * The strip takes no pointer events; only the button on it does. Anything wider would
-			 * shadow the card button underneath and cost it both its click and its hover.
-			 */}
-			{/*
-			 * Centred against the card, not pinned to its top.
-			 *
-			 * `top-3` put it level with the first line of the title, which is right only when the card
-			 * is exactly one line tall. A two-line description makes the card taller and leaves the
-			 * button sitting up in a corner, which reads as though it belongs to the title rather than
-			 * to the entry.
-			 */}
-			<div className="pointer-events-none absolute inset-y-0 right-3 flex items-center gap-0.5">
-				{installed ? (
-					<button
-						type="button"
-						aria-label={`${item.name} 的更多操作`}
-						aria-haspopup="menu"
-						aria-expanded={menu.open}
-						onClick={menu.toggle}
-						className="pointer-events-auto flex h-[26px] w-[26px] items-center justify-center rounded-md text-ink-faint opacity-0 transition-[color,background-color,opacity] duration-[var(--ly-t-quick)] group-hover/card:opacity-100 hover:bg-card-hover hover:text-ink focus-visible:opacity-100 aria-expanded:opacity-100"
-					>
-						{busy === "uninstall" ? (
-							<Loader2 size={13} strokeWidth={2} className="ly-spin" />
-						) : (
-							<MoreHorizontal size={15} strokeWidth={1.9} />
+						{/*
+						 * Installed-and-off is worth a word; installed-and-on is what the switch beside
+						 * it already says. An MCP bundle starts with every server off, so "未启用" is
+						 * where it begins rather than something the user did.
+						 */}
+						{installed && !isEnabled(item) && item.collected === 0 && (
+							<span className="shrink-0 text-caption text-ink-faint">
+								{item.kind === "mcp" ? "未启用" : "已停用"}
+							</span>
 						)}
-					</button>
-				) : (
-					item.entry && (
-						<button
-							type="button"
-							disabled={busy !== null}
-							onClick={() => void install()}
-							className="pointer-events-auto flex h-[26px] items-center gap-1.5 rounded-lg border border-line bg-shell/80 px-2.5 text-detail text-ink-muted transition-[color,border-color,opacity] duration-[var(--ly-t-quick)] hover:border-ink-faint hover:text-ink disabled:opacity-50"
-						>
-							{busy === "install" ? (
-								<Loader2 size={11.5} strokeWidth={2} className="ly-spin" />
-							) : (
-								<Download size={11.5} strokeWidth={1.9} />
+
+						{/* At the end of the title row rather than over it. `ml-auto` is the whole
+						    layout: the title truncates against whatever these leave. */}
+						<div className="ml-auto flex shrink-0 items-center gap-1">
+							{item.outdated && (
+								<button
+									type="button"
+									disabled={act.busy !== null}
+									data-ly-tip={`更新到 ${item.entry?.version ? `v${item.entry.version}` : "最新版本"}`}
+									onClick={() => void act.update()}
+									className="pointer-events-auto flex h-[26px] items-center gap-1 rounded-lg bg-accent/12 px-2 text-detail font-medium text-accent transition-opacity duration-[var(--ly-t-quick)] hover:opacity-80 disabled:opacity-50"
+								>
+									{act.busy === "update" ? (
+										<Loader2 size={11.5} strokeWidth={2} className="ly-spin" />
+									) : (
+										<ArrowUp size={11.5} strokeWidth={2.2} />
+									)}
+									更新
+								</button>
 							)}
-							安装
-						</button>
-					)
-				)}
+
+							{switchable && <Switch on={isEnabled(item)} label={item.name} onChange={(next) => onToggle(next)} />}
+
+							{installed ? (
+								<button
+									type="button"
+									aria-label={`${item.name} 的更多操作`}
+									aria-haspopup="menu"
+									aria-expanded={menu.open}
+									onClick={menu.toggle}
+									className="pointer-events-auto flex h-[26px] w-[26px] items-center justify-center rounded-md text-ink-faint opacity-0 transition-[color,background-color,opacity] duration-[var(--ly-t-quick)] group-hover/card:opacity-100 hover:bg-card-hover hover:text-ink focus-visible:opacity-100 aria-expanded:opacity-100"
+								>
+									{act.busy === "uninstall" ? (
+										<Loader2 size={13} strokeWidth={2} className="ly-spin" />
+									) : (
+										<MoreHorizontal size={15} strokeWidth={1.9} />
+									)}
+								</button>
+							) : (
+								item.entry && (
+									<button
+										type="button"
+										disabled={act.busy !== null}
+										onClick={() => void act.install()}
+										className="pointer-events-auto flex h-[26px] items-center gap-1.5 rounded-lg border border-line bg-shell/80 px-2.5 text-detail text-ink-muted transition-[color,border-color,opacity] duration-[var(--ly-t-quick)] hover:border-ink-faint hover:text-ink disabled:opacity-50"
+									>
+										{act.busy === "install" ? (
+											<Loader2 size={11.5} strokeWidth={2} className="ly-spin" />
+										) : (
+											<Download size={11.5} strokeWidth={1.9} />
+										)}
+										安装
+									</button>
+								)
+							)}
+						</div>
+					</div>
+
+					<IdentityLine item={item} />
+
+					{/*
+					 * The tagline when a maintainer wrote one, because it was written for this space.
+					 * A description is written to be read whole and wraps to three lines in a card.
+					 */}
+					<p className="mt-1.5 line-clamp-2 text-detail leading-relaxed text-ink-muted">
+						{item.tagline || item.description || "（没有描述）"}
+					</p>
+
+					<FootprintLine item={item} />
+				</div>
 			</div>
 
-
-			{/* The question is a modal now, so the menu is only ever a menu — see `Confirm`. */}
-			{confirming && (
+			{/* The question is a modal, so the menu is only ever a menu — see `Confirm`. */}
+			{act.confirming && (
 				<Confirm
 					title={`卸载 ${item.name}？`}
 					detail={
@@ -237,10 +224,10 @@ export function CatalogCard({
 								: "它的目录会被删除，随它安装的技能也一起消失。重新安装可以拿回来。"
 					}
 					confirmLabel="卸载"
-					onCancel={() => setConfirming(false)}
+					onCancel={() => act.setConfirming(false)}
 					onConfirm={() => {
-						setConfirming(false);
-						void uninstall();
+						act.setConfirming(false);
+						void act.uninstall();
 					}}
 				/>
 			)}
@@ -257,54 +244,83 @@ export function CatalogCard({
 					label={item.name}
 				>
 					<MenuBody>
-							{trial && (
-								<MenuItem
-									icon={<Play size={13} strokeWidth={1.8} />}
-									onClick={() => {
-										close();
-										onTry(trial);
-									}}
-								>
-									立即试用
-								</MenuItem>
-							)}
+						{trial && (
 							<MenuItem
-								icon={<Settings2 size={13} strokeWidth={1.8} />}
+								icon={<Play size={13} strokeWidth={1.8} />}
 								onClick={() => {
 									close();
-									onOpen();
+									onTry(trial);
 								}}
 							>
-								管理
+								立即试用
 							</MenuItem>
-							<MenuItem
-								icon={<FolderOpen size={13} strokeWidth={1.8} />}
-								onClick={() => {
-									close();
-									void window.lyra.system.openPath(dir);
-								}}
-							>
-								打开目录
-							</MenuItem>
+						)}
+						<MenuItem
+							icon={<Settings2 size={13} strokeWidth={1.8} />}
+							onClick={() => {
+								close();
+								onOpen();
+							}}
+						>
+							管理
+						</MenuItem>
+						<MenuItem
+							icon={<FolderOpen size={13} strokeWidth={1.8} />}
+							onClick={() => {
+								close();
+								void window.lyra.system.openPath(dir);
+							}}
+						>
+							打开目录
+						</MenuItem>
 
-							<MenuSeparator />
+						<MenuSeparator />
 
-							<MenuItem
-								danger
-								icon={<Trash2 size={13} strokeWidth={1.8} />}
-								disabled={busy !== null || !removable}
-								title={removable ? undefined : "项目里的插件，从项目目录里删"}
-								onClick={() => {
-									// The menu gives way to the question rather than sitting behind it.
-									menu.close();
-									setConfirming(true);
-								}}
-							>
-								卸载
-							</MenuItem>
-						</MenuBody>
+						<MenuItem
+							danger
+							icon={<Trash2 size={13} strokeWidth={1.8} />}
+							disabled={act.busy !== null || !removable}
+							title={removable ? undefined : "项目里的插件，从项目目录里删"}
+							onClick={() => {
+								// The menu gives way to the question rather than sitting behind it.
+								menu.close();
+								act.setConfirming(true);
+							}}
+						>
+							卸载
+						</MenuItem>
+					</MenuBody>
 				</Popover>
 			)}
 		</div>
+	);
+}
+
+/**
+ * On or off, for the one kind that has a single answer.
+ *
+ * Drawn rather than an `<input type=checkbox>` because the platform control cannot be restyled to
+ * this size on every OS the app ships to, and a switch that looks different on Windows than on
+ * macOS in the middle of a card that looks the same is worse than one we draw.
+ */
+function Switch({ on, label, onChange }: { on: boolean; label: string; onChange: (next: boolean) => void }) {
+	return (
+		<button
+			type="button"
+			role="switch"
+			aria-checked={on}
+			aria-label={`${label}${on ? "（已启用）" : "（已停用）"}`}
+			data-ly-tip={on ? "停用" : "启用"}
+			onClick={() => onChange(!on)}
+			className={`pointer-events-auto flex h-[16px] w-[28px] shrink-0 items-center rounded-full px-[2px] transition-colors duration-[var(--ly-t-quick)] ${
+				on ? "bg-ok" : "bg-line"
+			}`}
+		>
+			<span
+				className={`h-[12px] w-[12px] rounded-full bg-shell transition-transform duration-[var(--ly-t-quick)] ${
+					on ? "translate-x-[12px]" : "translate-x-0"
+				}`}
+			/>
+		</button>
 	);
 }

--- a/packages/desktop/src/components/plugins/catalog.ts
+++ b/packages/desktop/src/components/plugins/catalog.ts
@@ -18,7 +18,10 @@
  * registry says it is.
  */
 
-import type { BundleKind, McpBundle, McpServerConfig, Plugin, RegistryEntry, Skill } from "@lyra/core";
+import type { BundleKind, ClientId, InstallRecord, McpBundle, McpServerConfig, Plugin, RegistryEntry, Skill } from "@lyra/core";
+// A sub-entry, not the root: importing a value from `@lyra/core` pulls its whole index — and with
+// it `node:fs` — into this bundle. See AGENTS.md.
+import { isOutdated } from "@lyra/core/install-record";
 
 /** Bundles with nothing to file them under. Not a category anyone chose — see `groupByCategory`. */
 export const UNFILED = " unfiled";
@@ -61,6 +64,33 @@ export interface CatalogItem {
 	entry: RegistryEntry | null;
 	/** Which registry offered it, for the rare case of two offering the same name. */
 	from: string | null;
+
+	/*
+	 * What the card says about a bundle besides its name.
+	 *
+	 * Every one of these was already being fetched and thrown away: the platform has published
+	 * `version`, `author`, `downloads`, `skillCount` and `clients` since it existed, and the site
+	 * has shown all of them on its own cards the whole time. The desktop card drew a name and a
+	 * description, so the two views of the same catalogue disagreed about how much was known.
+	 *
+	 * Optional, all of them, because a bundle sitting in `~/.lyra/plugins` came from a directory
+	 * rather than an index and genuinely has no author, no download count and no version beyond
+	 * what its own manifest claims. A missing field is left out of the line rather than filled.
+	 */
+	/** A maintainer's short line, preferred over `description` where space is tight. */
+	tagline?: string;
+	version?: string;
+	author?: string;
+	downloads?: number;
+	/** How many skills it holds: counted on disk once installed, claimed by the index before that. */
+	skillCount?: number;
+	serverCount?: number;
+	/** Which agents can install it, derived by the platform from the archive's contents. */
+	clients?: ClientId[];
+	/** What the registry said this was when it was installed. Absent for anything not installed. */
+	origin?: InstallRecord;
+	/** Installed, and what the registry now offers is not what was installed. See `isOutdated`. */
+	outdated: boolean;
 }
 
 /** On disk, in whichever way this kind arrives — the question every "do I have this" check asks. */
@@ -152,6 +182,19 @@ export function merge(
 			servers: [],
 			entry: null,
 			from: null,
+			/*
+			 * The version on disk, and the author who wrote the manifest.
+			 *
+			 * The registry's copy of both is attached below and deliberately does not overwrite
+			 * these: what is installed is what is running, and a registry that has moved on since
+			 * should not relabel it. That is the same rule the name and description follow.
+			 */
+			version: plugin.manifest.version,
+			author: typeof plugin.manifest.author === "string" ? plugin.manifest.author : plugin.manifest.author?.name,
+			// Counted, not claimed — the loader already read the directory.
+			skillCount: plugin.skills.length,
+			origin: plugin.origin,
+			outdated: false,
 		});
 	}
 
@@ -174,6 +217,12 @@ export function merge(
 			servers: configured.filter((server) => server.origin?.bundle === bundle.id),
 			entry: null,
 			from: null,
+			version: bundle.manifest.version,
+			author: typeof bundle.manifest.author === "string" ? bundle.manifest.author : bundle.manifest.author?.name,
+			// What its `.mcp.json` declares, which is what install read to write the settings rows.
+			serverCount: bundle.servers.length,
+			origin: bundle.origin,
+			outdated: false,
 		});
 	}
 
@@ -186,6 +235,29 @@ export function merge(
 			if (!existing.description) existing.description = entry.description ?? "";
 			if (!existing.logo) existing.logo = entry.logo;
 			if (existing.category === UNFILED && entry.category) existing.category = entry.category;
+			/*
+			 * The same rule for everything the index also knows: fill the gaps, overwrite nothing.
+			 *
+			 * A manifest that named its author speaks for the bundle running on this machine; the
+			 * index's copy may be months stale. The exceptions below are the three the index is the
+			 * only possible source for — nothing on disk counts downloads, records who else can
+			 * install it, or knows what a maintainer wrote in a console.
+			 */
+			existing.tagline ??= entry.tagline;
+			existing.version ??= entry.version;
+			existing.author ??= entry.author;
+			existing.skillCount ??= entry.skillCount;
+			existing.serverCount ??= entry.serverCount;
+			existing.downloads = entry.downloads;
+			existing.clients = entry.clients;
+			/*
+			 * Whether what is on offer differs from what was installed.
+			 *
+			 * Only answerable here, which is why it is computed here rather than in either process:
+			 * the record comes from the main process's scan of the disk and the entry comes from a
+			 * registry this window fetched, and this is the first place both are in scope.
+			 */
+			existing.outdated = isOutdated(existing.origin, entry);
 			continue;
 		}
 		// Which of the loose skills this collection put there — none, unless it is a collection.
@@ -206,6 +278,16 @@ export function merge(
 			servers: [],
 			entry,
 			from,
+			tagline: entry.tagline,
+			version: entry.version,
+			author: entry.author,
+			downloads: entry.downloads,
+			skillCount: entry.skillCount,
+			serverCount: entry.serverCount,
+			clients: entry.clients,
+			// Nothing is installed, so there is nothing to be behind. A collection whose skills are
+			// on disk has no record either — `moveInto` leaves no directory to have written one for.
+			outdated: false,
 		});
 	}
 

--- a/packages/desktop/src/components/plugins/toggle.ts
+++ b/packages/desktop/src/components/plugins/toggle.ts
@@ -1,0 +1,50 @@
+/**
+ * Switching a plugin on or off, as a decision rather than a handler.
+ *
+ * Two screens do this now — the settings list and the catalogue card — and it is not the one-line
+ * set-add-or-delete it looks like, because of the wildcard. Written twice it would be right in one
+ * place and subtly wrong in the other, and the wrong one produces a switch that reports a change
+ * and makes none: the id is removed, `*` stays, and everything is still off after a reload.
+ *
+ * A pure function over the settings, so the rule can be tested without a renderer.
+ */
+
+import type { Plugin, Settings } from "@lyra/core";
+
+/**
+ * The settings after this plugin is switched on or off.
+ *
+ * `*` in `disabledPlugins` means "none of them", whoever wrote it there — a session that has to be
+ * reproducible sets it without knowing what is installed. Turning one plugin back on therefore
+ * means naming what the wildcard stood for: everything currently on disk except this one. Leaving
+ * the wildcard in place while deleting the id is the bug this function exists to prevent.
+ *
+ * `installed` is every plugin the scan found, and it is only read on that one path.
+ */
+export function settingsAfterToggle(
+	settings: Settings,
+	plugin: Plugin,
+	enabled: boolean,
+	installed: Plugin[],
+): Settings {
+	const disabled = new Set(settings.disabledPlugins);
+	if (disabled.has("*") && enabled) {
+		disabled.delete("*");
+		for (const other of installed) if (other.id !== plugin.id) disabled.add(other.id);
+	}
+	if (enabled) {
+		disabled.delete(plugin.id);
+		/*
+		 * And whatever it used to be called.
+		 *
+		 * `disabledPlugins` holds whatever `id` meant when the user switched something off, which for
+		 * entries written by older versions was the manifest's name rather than the directory. The
+		 * loader reads both when deciding `enabled`, so switching on has to clear both or the plugin
+		 * comes back off — see the note beside that check in `loader.ts`.
+		 */
+		if (plugin.manifest.name) disabled.delete(plugin.manifest.name);
+	} else {
+		disabled.add(plugin.id);
+	}
+	return { ...settings, disabledPlugins: [...disabled] };
+}

--- a/packages/desktop/src/components/plugins/useInstall.ts
+++ b/packages/desktop/src/components/plugins/useInstall.ts
@@ -1,0 +1,93 @@
+/**
+ * The three things that can be done to a bundle, and what is true while one of them is happening.
+ *
+ * Extracted from the card because the card is now a layout and this is a state machine, and because
+ * the detail page runs the same three operations against the same entry — two copies of "set busy,
+ * call, read the result, say something if the kind turned out different, refresh" is two places for
+ * the ordering to drift.
+ *
+ * Every operation reports through `onError` rather than throwing. A failed install is a sentence
+ * the user needs to read, not an exception that unmounts the grid they were reading it from.
+ */
+
+import { useState } from "react";
+
+import type { CatalogItem } from "./catalog.ts";
+
+/** Which operation is in flight, or null. Drives the spinner and disables the controls. */
+export type Busy = "install" | "update" | "uninstall" | null;
+
+export interface Install {
+	busy: Busy;
+	/** Whether the uninstall confirmation is showing. See the note on `Confirm`. */
+	confirming: boolean;
+	setConfirming: (value: boolean) => void;
+	install: () => Promise<void>;
+	update: () => Promise<void>;
+	uninstall: () => Promise<void>;
+}
+
+export function useInstall(
+	item: CatalogItem,
+	/** Something on disk moved; the catalogue has to be re-read. */
+	onChanged: () => void,
+	onError: (message: string) => void,
+): Install {
+	const [busy, setBusy] = useState<Busy>(null);
+	const [confirming, setConfirming] = useState(false);
+
+	/**
+	 * Install or replace, which is the same call with one flag.
+	 *
+	 * They differ in exactly one thing the user can see — the word on the button — because the flag
+	 * is the whole difference on disk too: the new bundle is staged and verified either way, and
+	 * `replace` only says whether an existing directory is a reason to stop.
+	 */
+	const run = async (replace: boolean) => {
+		if (!item.entry) return;
+		setBusy(replace ? "update" : "install");
+		const result = await window.lyra.plugins.installFromRegistry(item.entry, item.from ?? undefined, replace);
+		setBusy(null);
+		if (!result.ok) {
+			onError(`${item.name}：${result.message}`);
+			return;
+		}
+		/*
+		 * Said out loud when the index was wrong about what this is.
+		 *
+		 * The kind on the card came from the registry, and the registry is guessing; the clone is
+		 * what settles it. Landing an MCP server in the plugins tab without a word would leave
+		 * someone looking for it under the wrong heading, and its servers arrive switched off, so
+		 * there is a second thing to do that nothing else would mention.
+		 *
+		 * Only on a first install. An update that reports the same correction every time is noise
+		 * about something the user already dealt with once.
+		 */
+		// `kind` is absent when the main process predates the split — say nothing rather than
+		// claim it turned out to be something else.
+		if (!replace && result.kind && result.kind !== item.kind) {
+			onError(
+				result.kind === "mcp"
+					? `${item.name} 其实是一个 MCP 服务，已装到「MCP 服务」下；它的 ${result.servers} 个服务默认关着，去设置 › MCP 里开。`
+					: `${item.name} 其实是一个插件，已装到「插件」下。`,
+			);
+		} else if (!replace && result.kind === "mcp") {
+			onError(`${item.name} 已安装，${result.servers} 个服务默认关着——去设置 › MCP 里开。`);
+		}
+		onChanged();
+	};
+
+	return {
+		busy,
+		confirming,
+		setConfirming,
+		install: () => run(false),
+		update: () => run(true),
+		uninstall: async () => {
+			setBusy("uninstall");
+			await window.lyra.plugins.uninstall(item.id);
+			setBusy(null);
+			onChanged();
+		},
+	};
+}

--- a/packages/desktop/src/components/settings/PluginIcon.tsx
+++ b/packages/desktop/src/components/settings/PluginIcon.tsx
@@ -84,23 +84,30 @@ function KindMark({ kind, brandColor, size }: { kind: BundleKind; brandColor?: s
 			style={{
 				width: size,
 				height: size,
-				borderRadius: Math.round(size * 0.28),
-				// Mixed rather than set flat: a brand colour is chosen to be seen against white, and a
-				// 36px tile of it beside eight grey ones is a page where the loudest entry is whichever
-				// one filled in an optional field.
+				borderRadius: Math.round(size * 0.235),
+				/*
+				 * Mixed down, and graded rather than flat.
+				 *
+				 * Mixed because a brand colour is chosen to be legible against white, and a 38px tile
+				 * of it beside eight quiet ones makes the loudest thing on the page whichever author
+				 * filled in an optional field. Graded because a flat wash at 12% reads as a failed
+				 * image — the same fallback the platform serves for entries with no icon at all, and
+				 * these two have to look like one thing since they appear side by side in the same
+				 * grid. The numbers match `placeholder()` in the registry's icon route.
+				 */
 				...(colour
 					? {
-							background: `color-mix(in srgb, ${colour} 12%, transparent)`,
-							borderColor: `color-mix(in srgb, ${colour} 28%, transparent)`,
+							background: `linear-gradient(to bottom, color-mix(in srgb, ${colour} 16%, transparent), color-mix(in srgb, ${colour} 6%, transparent))`,
+							borderColor: `color-mix(in srgb, ${colour} 22%, transparent)`,
 							color: colour,
 						}
 					: {}),
 			}}
 			className={`flex shrink-0 items-center justify-center border ${
-				colour ? "" : "border-line-soft bg-card/60 text-ink-faint"
+				colour ? "" : "border-line-soft bg-gradient-to-b from-card to-card/40 text-ink-faint"
 			}`}
 		>
-			<Glyph size={Math.round(size * 0.46)} strokeWidth={1.7} />
+			<Glyph size={Math.round(size * 0.42)} strokeWidth={1.7} />
 		</span>
 	);
 }

--- a/packages/desktop/src/components/settings/PluginsSettings.tsx
+++ b/packages/desktop/src/components/settings/PluginsSettings.tsx
@@ -19,6 +19,7 @@ import { Confirm } from "../Confirm.tsx";
 import { MenuBody, MenuItem, MenuSeparator, Popover, usePopover } from "../Popover.tsx";
 import { useApp } from "../../store.ts";
 import { SkeletonList, useSlowLoad } from "../Skeleton.tsx";
+import { settingsAfterToggle } from "../plugins/toggle.ts";
 import { Card, ListRow, Toggle } from "./controls.tsx";
 import { PluginIcon } from "./PluginIcon.tsx";
 
@@ -57,25 +58,12 @@ export function PluginsSettings({ filter = "" }: { filter?: string }) {
 	);
 	const diagnostics = scan?.pluginDiagnostics ?? [];
 
-	/*
-	 * `*` in `disabledPlugins` means "none of them", whoever wrote it there.
-	 *
-	 * Switching one back on has to clear that as well, or the toggle is a control that reports a
-	 * change and produces none: the id is removed, the wildcard stays, and every plugin is still
-	 * off after a reload. Turning the wildcard off means naming what it stood for — everything
-	 * currently on disk except the one being switched on.
-	 */
+	/* `*` means "none of them" and is still shown to the user below; the rule for clearing it lives
+	   in `settingsAfterToggle`, because the catalogue card switches plugins too. */
 	const allOff = settings.disabledPlugins.includes("*");
 
 	const toggle = (plugin: Plugin, enabled: boolean) => {
-		const disabled = new Set(settings.disabledPlugins);
-		if (allOff && enabled) {
-			disabled.delete("*");
-			for (const other of scan?.plugins ?? []) if (other.id !== plugin.id) disabled.add(other.id);
-		}
-		if (enabled) disabled.delete(plugin.id);
-		else disabled.add(plugin.id);
-		void saveSettings({ ...settings, disabledPlugins: [...disabled] });
+		void saveSettings(settingsAfterToggle(settings, plugin, enabled, scan?.plugins ?? []));
 	};
 
 	/** The bundle's own page, in the catalogue — which is a different view, not a panel in here. */

--- a/packages/desktop/test/catalog-merge.test.ts
+++ b/packages/desktop/test/catalog-merge.test.ts
@@ -127,3 +127,82 @@ test("a main process that has never heard of MCP bundles does not take the page 
 	assert.equal(merge([plugin("waza")], missing, [], []).length, 1);
 	assert.deepEqual(merge([], [bundle("context7", [server("c7")])], noSettings, [])[0].servers, []);
 });
+
+/*
+ * What a card is allowed to say about a bundle, and where each fact comes from.
+ *
+ * The rule is the same one the name and description already follow, extended to the rest: what is
+ * installed is what is running, so a manifest on disk outranks an index that may have moved on.
+ * The exceptions are the facts no directory can hold — nobody's disk knows how many other people
+ * installed it, which agents can use it, or what a maintainer typed into a console.
+ */
+
+test("an entry's own fields reach the card", () => {
+	const rich: RegistryEntry = {
+		...entry("waza", "skill"),
+		version: "1.2.3",
+		author: "tw93",
+		downloads: 42,
+		skillCount: 8,
+		clients: ["claude-code", "lyra"],
+		tagline: "五个字",
+	};
+	const [item] = merge([], [], [], [{ from: "Lyra Registry", entry: rich }]);
+
+	assert.equal(item.version, "1.2.3");
+	assert.equal(item.author, "tw93");
+	assert.equal(item.downloads, 42);
+	assert.equal(item.skillCount, 8);
+	assert.deepEqual(item.clients, ["claude-code", "lyra"]);
+	assert.equal(item.tagline, "五个字");
+});
+
+test("the installed manifest wins over the index, and the index fills what it left blank", () => {
+	const installed = plugin("waza");
+	installed.manifest = { name: "waza", version: "0.9.0", author: { name: "本地作者" } };
+	const offered: RegistryEntry = { ...entry("waza", "plugin"), version: "2.0.0", author: "索引作者", downloads: 7 };
+
+	const [item] = merge([installed], [], [], [{ from: "r", entry: offered }]);
+
+	assert.equal(item.version, "0.9.0", "the copy on disk is the one running");
+	assert.equal(item.author, "本地作者");
+	// Nothing on disk counts installs, so this can only come from the index.
+	assert.equal(item.downloads, 7);
+});
+
+test("an installed bundle whose manifest says nothing takes the index's word", () => {
+	const bare = plugin("waza");
+	bare.manifest = { name: "waza" };
+	const offered: RegistryEntry = { ...entry("waza", "plugin"), version: "2.0.0", author: "索引作者" };
+
+	const [item] = merge([bare], [], [], [{ from: "r", entry: offered }]);
+
+	assert.equal(item.version, "2.0.0");
+	assert.equal(item.author, "索引作者");
+});
+
+test("a plugin reports the skills the loader actually found, not the number claimed", () => {
+	const withSkills = plugin("waza");
+	withSkills.skills = [
+		{ name: "a", description: "", dir: "/d/a", source: "user" },
+		{ name: "b", description: "", dir: "/d/b", source: "user" },
+	] as unknown as typeof withSkills.skills;
+	const offered: RegistryEntry = { ...entry("waza", "plugin"), skillCount: 99 };
+
+	const [item] = merge([withSkills], [], [], [{ from: "r", entry: offered }]);
+	assert.equal(item.skillCount, 2, "counted on disk beats claimed in an index");
+});
+
+test("an update is only claimed when the installed copy carries a comparable record", () => {
+	const known = plugin("waza");
+	known.origin = { id: "waza", installedAt: "2026-08-01T00:00:00.000Z", commit: "aaa" };
+	const moved: RegistryEntry = { ...entry("waza", "plugin"), commit: "bbb" };
+
+	assert.equal(merge([known], [], [], [{ from: "r", entry: moved }])[0].outdated, true);
+	assert.equal(merge([known], [], [], [{ from: "r", entry: { ...moved, commit: "aaa" } }])[0].outdated, false);
+
+	// Installed by hand, or before the ledger existed: no record, so nothing may be claimed.
+	assert.equal(merge([plugin("waza")], [], [], [{ from: "r", entry: moved }])[0].outdated, false);
+	// And nothing that is not installed can be behind anything.
+	assert.equal(merge([], [], [], [{ from: "r", entry: moved }])[0].outdated, false);
+});

--- a/packages/desktop/test/plugin-toggle.test.ts
+++ b/packages/desktop/test/plugin-toggle.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Switching a plugin on and off, which is not the set operation it looks like.
+ *
+ * Two things make it awkward, and both produce the same symptom when got wrong: a switch that
+ * reports a change and produces none, with the plugin still off after a reload.
+ *
+ * The wildcard is the first. `disabledPlugins: ["*"]` means "none of them", and turning one back on
+ * has to name what the wildcard stood for rather than just deleting an id that was never in the
+ * list. The second is the old name: entries written by earlier versions hold the manifest's name
+ * where they now hold the directory, and the loader reads both when deciding `enabled`.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { Plugin, Settings } from "@lyra/core";
+
+import { settingsAfterToggle } from "../src/components/plugins/toggle.ts";
+
+function plugin(id: string, name = id): Plugin {
+	return {
+		id,
+		dir: `/home/me/.lyra/plugins/${id}`,
+		manifest: { name },
+		source: "user",
+		skills: [],
+		enabled: true,
+	};
+}
+
+function settings(disabledPlugins: string[]): Settings {
+	return { disabledPlugins } as Settings;
+}
+
+const WAZA = plugin("waza");
+const OTHER = plugin("context7");
+
+test("switching off adds the directory name", () => {
+	const next = settingsAfterToggle(settings([]), WAZA, false, [WAZA, OTHER]);
+	assert.deepEqual(next.disabledPlugins, ["waza"]);
+});
+
+test("switching on removes it", () => {
+	const next = settingsAfterToggle(settings(["waza", "context7"]), WAZA, true, [WAZA, OTHER]);
+	assert.deepEqual(next.disabledPlugins, ["context7"]);
+});
+
+test("switching one on under a wildcard names everything the wildcard stood for", () => {
+	/*
+	 * The case the whole function exists for. Deleting `waza` from a list that does not contain it
+	 * and leaving `*` in place is a no-op that looks like a change.
+	 */
+	const next = settingsAfterToggle(settings(["*"]), WAZA, true, [WAZA, OTHER]);
+	assert.equal(next.disabledPlugins.includes("*"), false);
+	assert.equal(next.disabledPlugins.includes("waza"), false);
+	assert.equal(next.disabledPlugins.includes("context7"), true);
+});
+
+test("switching one off under a wildcard leaves the wildcard alone", () => {
+	// It is already off. Expanding the wildcard here would be rewriting the user's setting to say
+	// the same thing at greater length, and would stop meaning "whatever is installed".
+	const next = settingsAfterToggle(settings(["*"]), WAZA, false, [WAZA, OTHER]);
+	assert.equal(next.disabledPlugins.includes("*"), true);
+});
+
+test("switching on also clears the name an older version wrote", () => {
+	/*
+	 * `agentic-note-taking` on disk calls itself `Agentic Note Taking` in its manifest, and older
+	 * builds wrote that string here. The loader still reads both, so clearing only the directory
+	 * leaves the plugin off — and the switch says it is on.
+	 */
+	const renamed = plugin("agentic-note-taking", "Agentic Note Taking");
+	const next = settingsAfterToggle(settings(["Agentic Note Taking"]), renamed, true, [renamed]);
+	assert.deepEqual(next.disabledPlugins, []);
+});
+
+test("the rest of the settings are carried through untouched", () => {
+	const before = { disabledPlugins: [], theme: "dark" } as unknown as Settings;
+	const next = settingsAfterToggle(before, WAZA, false, [WAZA]);
+	assert.equal((next as unknown as { theme: string }).theme, "dark");
+	// And the original is not mutated: the store compares by identity to decide what to re-render.
+	assert.deepEqual(before.disabledPlugins, []);
+});

--- a/packages/registry-shared/src/api.ts
+++ b/packages/registry-shared/src/api.ts
@@ -46,8 +46,19 @@ export function isEntrySort(value: unknown): value is EntrySort {
 }
 
 /** A catalogue row: an index entry plus what only the platform knows about it. */
+/**
+ * Where the picture behind `logo` is currently coming from.
+ *
+ * `logo` is always our own URL, which is what makes a catalogue drawable by a viewer who cannot
+ * reach GitHub — and what makes the source invisible. A maintainer deciding whether to upload a
+ * replacement needs to know whether they would be overriding the author's own icon or filling a
+ * gap, and those are the same picture-shaped hole from the outside.
+ */
+export type IconSource = "uploaded" | "bundled" | "remote" | "none";
+
 export interface EntrySummary extends RegistryEntry {
 	status: EntryStatus;
+	iconSource?: IconSource;
 	/** GitHub login of whoever claimed it here — not necessarily the code's author. */
 	publisher?: string;
 	publisherAvatar?: string;
@@ -61,6 +72,12 @@ export interface EntryDetail extends EntrySummary {
 	versions: VersionInfo[];
 	/** The README the build found in the bundle, as raw markdown. Rendered by the client. */
 	readme?: string;
+	/**
+	 * Directory the README's relative links resolve against, relative to the repository root.
+	 *
+	 * `""` means the repository root, which is where a bundle with no README of its own gets one.
+	 */
+	readmeBase?: string;
 	/** Present only for the entry's own publisher or an admin. */
 	reviewNote?: string;
 }

--- a/packages/registry-shared/src/clients.ts
+++ b/packages/registry-shared/src/clients.ts
@@ -1,0 +1,105 @@
+/**
+ * Which agents can actually install a given thing.
+ *
+ * This registry is not tied to one client, and that is a fact about the formats rather than a
+ * marketing position. `SKILL.md` is a convention Claude Code established and Codex, Pi and Lyra all
+ * read; `.mcp.json` describes an MCP server, and MCP is a protocol with many clients. A directory
+ * of skills genuinely does install into all of them.
+ *
+ * What is *not* portable is a plugin manifest: `.claude-plugin/` and `.lyra-plugin/` are each one
+ * product's format. So compatibility is neither "everything" nor "whatever the author ticked" — it
+ * is read off the archive, the same way `kind` is, and for the same reason: a claim in a form is a
+ * claim, and this one would be wrong the moment somebody copied a submission template.
+ */
+
+import type { BundleKind } from "./entry.ts";
+
+/** A client that can install something from here. `mcp` is the protocol, not one product. */
+export type ClientId = "claude-code" | "codex" | "lyra" | "pi" | "mcp";
+
+export const CLIENTS: readonly ClientId[] = ["claude-code", "codex", "pi", "lyra", "mcp"];
+
+export function isClientId(value: unknown): value is ClientId {
+	return CLIENTS.includes(value as ClientId);
+}
+
+/** Display names, in one place because they appear on cards, on detail pages and in the API. */
+export const CLIENT_LABEL: Record<ClientId, string> = {
+	"claude-code": "Claude Code",
+	codex: "Codex",
+	pi: "Pi",
+	lyra: "Lyra",
+	mcp: "任何 MCP 客户端",
+};
+
+/**
+ * Where each client keeps the thing, once installed.
+ *
+ * Shown on the detail page so somebody can install by hand — which is the honest fallback for
+ * every client that has no marketplace of its own, and that is most of them.
+ */
+export const CLIENT_SKILL_PATH: Partial<Record<ClientId, string>> = {
+	"claude-code": "~/.claude/skills/",
+	codex: "~/.codex/skills/",
+	pi: "~/.pi/skills/",
+	lyra: "~/.lyra/skills/",
+};
+
+export interface Evidence {
+	/** At least one `<name>/SKILL.md`, which is the portable format. */
+	skills: boolean;
+	/** A `.mcp.json` declaring servers. */
+	mcp: boolean;
+	/** `.claude-plugin/` — Claude Code's own plugin layout. */
+	claudePlugin: boolean;
+	/** `.lyra-plugin/` — Lyra's. */
+	lyraPlugin: boolean;
+	/** `.codex-plugin/` — read separately rather than inferred from Lyra's, see `clientsFor`. */
+	codexPlugin: boolean;
+}
+
+/**
+ * Which clients this archive works with, from what it contains.
+ *
+ * Skills are the portable case: every agent listed reads a directory of `SKILL.md` folders. An MCP
+ * server is reported as `mcp` rather than as a list of products, because the set of MCP clients is
+ * open and naming five would quietly imply the sixth does not work.
+ *
+ * `kind` is a parameter because a plugin manifest only says something when the thing *is* a plugin.
+ * Context7 is a `.mcp.json` and a `.lyra-plugin/` directory holding a name, an icon and a
+ * description — metadata, not a plugin — and reading that directory as evidence had it advertised
+ * as installable into Codex and Lyra as a plugin, which it is not. Measured on the live catalogue:
+ * three of five entries were labelled wrong.
+ *
+ * Returns an empty list rather than guessing when nothing recognisable is present. An entry
+ * claiming universal compatibility on no evidence is worse than one claiming none.
+ */
+export function clientsFor(kind: BundleKind, evidence: Evidence): ClientId[] {
+	const found = new Set<ClientId>();
+
+	if (evidence.skills) {
+		for (const client of ["claude-code", "codex", "pi", "lyra"] as const) found.add(client);
+	}
+	if (evidence.mcp) found.add("mcp");
+
+	if (kind === "plugin") {
+		if (evidence.claudePlugin) found.add("claude-code");
+		if (evidence.lyraPlugin) found.add("lyra");
+		// Not inferred from `.lyra-plugin/`. Lyra's loader happens to accept either directory name,
+		// which says what Lyra reads and nothing about what Codex installs.
+		if (evidence.codexPlugin) found.add("codex");
+	}
+
+	return CLIENTS.filter((client) => found.has(client));
+}
+
+/** Parse the comma-separated form stored in the database. Unknown values are dropped. */
+export function parseClients(raw: string | null | undefined): ClientId[] {
+	if (!raw) return [];
+	const wanted = new Set(raw.split(",").map((part) => part.trim()));
+	return CLIENTS.filter((client) => wanted.has(client));
+}
+
+export function serialiseClients(clients: ClientId[]): string {
+	return CLIENTS.filter((client) => clients.includes(client)).join(",");
+}

--- a/packages/registry-shared/src/entry.ts
+++ b/packages/registry-shared/src/entry.ts
@@ -12,6 +12,8 @@
  * not a replacement format.
  */
 
+import { isClientId, type ClientId } from "./clients.ts";
+
 /**
  * The three things a registry can offer, distinguished by where they land and what starts them.
  *
@@ -93,6 +95,22 @@ export interface RegistryEntry {
 	serverCount?: number;
 	/** The upstream commit this version was built from, so a build can be reproduced. */
 	commit?: string;
+	/**
+	 * Which agents can install this, derived from the archive's contents.
+	 *
+	 * Absent on a plain file-based index, which has no way to know — the field only means something
+	 * when something has read the bundle.
+	 */
+	clients?: ClientId[];
+	/**
+	 * A short line for a card, where the description is too long to be read.
+	 *
+	 * Written by a maintainer rather than derived: nothing in a manifest is short enough to be one,
+	 * and a truncated description is not a tagline — it is a description with the end cut off. A
+	 * client with room for a sentence should still show `description`; this is for the places that
+	 * have room for five words.
+	 */
+	tagline?: string;
 }
 
 /**
@@ -155,6 +173,11 @@ export function normalise(item: unknown): RegistryEntry | null {
 		skillCount: positive(raw.skillCount ?? raw.skill_count),
 		serverCount: positive(raw.serverCount ?? raw.server_count),
 		commit: pick(raw, "commit", "sha", "commitSha"),
+		clients: Array.isArray(raw.clients) ? raw.clients.filter(isClientId) : undefined,
+		// Only this one key. `summary` and `shortDescription` are already aliases for `description`
+		// above, so accepting them here would make an index that uses one of them produce a card
+		// showing the same sentence twice.
+		tagline: pick(raw, "tagline"),
 	};
 }
 

--- a/packages/registry-shared/src/index.ts
+++ b/packages/registry-shared/src/index.ts
@@ -32,6 +32,7 @@ export {
 	type EntryQuery,
 	type EntrySort,
 	type EntrySummary,
+	type IconSource,
 	type Page,
 	type RegistryStats,
 	type ReviewRequest,
@@ -40,4 +41,16 @@ export {
 	type Viewer,
 } from "./api.ts";
 
-export { normalisePath, ownerAvatar, parseRepo, tarballUrl, type RepoRef } from "./repo.ts";
+export { normalisePath, parseRepo, tarballUrl, type RepoRef } from "./repo.ts";
+
+export {
+	CLIENTS,
+	CLIENT_LABEL,
+	CLIENT_SKILL_PATH,
+	clientsFor,
+	isClientId,
+	parseClients,
+	serialiseClients,
+	type ClientId,
+	type Evidence,
+} from "./clients.ts";

--- a/packages/registry-shared/src/repo.ts
+++ b/packages/registry-shared/src/repo.ts
@@ -55,11 +55,6 @@ export function tarballUrl(ref: RepoRef, gitRef: string): string {
 	return `https://codeload.github.com/${ref.owner}/${ref.repo}/tar.gz/${encodeURIComponent(gitRef)}`;
 }
 
-/** The owner's avatar, which every GitHub project has and which never 404s. */
-export function ownerAvatar(ref: RepoRef, size = 128): string {
-	return `https://github.com/${ref.owner}.png?size=${size}`;
-}
-
 /**
  * A sub-path inside a repository, or null for anything absolute or climbing out of the checkout.
  *

--- a/packages/registry-shared/test/entry.test.ts
+++ b/packages/registry-shared/test/entry.test.ts
@@ -126,3 +126,34 @@ test("slugging a name gives something an id check accepts", () => {
 	assert.equal(slugOf("Chrome DevTools!!"), "chrome-devtools");
 	assert.ok(isValidId(slugOf("Sequential Thinking")));
 });
+
+test("compatibility is read off the archive, and a plugin manifest only counts for a plugin", async () => {
+	const { clientsFor } = await import("../src/clients.ts");
+	const none = { skills: false, mcp: false, claudePlugin: false, lyraPlugin: false, codexPlugin: false };
+
+	// Skills are the portable case: every agent that reads SKILL.md can install them.
+	assert.deepEqual(clientsFor("skill", { ...none, skills: true }), ["claude-code", "codex", "pi", "lyra"]);
+
+	/*
+	 * The bug this exists to prevent. Context7 is a `.mcp.json` plus a `.lyra-plugin/` directory
+	 * holding a name and an icon — metadata, not a plugin. Counting that directory as evidence
+	 * advertised it as installable into Lyra and Codex as a plugin, which it is not.
+	 */
+	assert.deepEqual(clientsFor("mcp", { ...none, mcp: true, lyraPlugin: true }), ["mcp"]);
+
+	// For something that really is a plugin, the manifest does say which product's format it is.
+	assert.deepEqual(clientsFor("plugin", { ...none, skills: true, lyraPlugin: true }), [
+		"claude-code",
+		"codex",
+		"pi",
+		"lyra",
+	]);
+	assert.deepEqual(clientsFor("plugin", { ...none, claudePlugin: true }), ["claude-code"]);
+
+	// Codex is never inferred from Lyra's directory, only from its own.
+	assert.deepEqual(clientsFor("plugin", { ...none, lyraPlugin: true }), ["lyra"]);
+	assert.deepEqual(clientsFor("plugin", { ...none, codexPlugin: true }), ["codex"]);
+
+	// Nothing recognisable claims nothing, rather than claiming everything.
+	assert.deepEqual(clientsFor("plugin", none), []);
+});

--- a/packages/registry-shared/test/repo.test.ts
+++ b/packages/registry-shared/test/repo.test.ts
@@ -9,7 +9,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { normalisePath, ownerAvatar, parseRepo, tarballUrl } from "../src/repo.ts";
+import { normalisePath, parseRepo, tarballUrl } from "../src/repo.ts";
 
 test("every form a repository is written in reaches the same pair", () => {
 	for (const raw of [
@@ -49,10 +49,6 @@ test("a tarball URL escapes its ref, because a branch name is user input", () =>
 	assert.equal(tarballUrl(ref, "main"), "https://codeload.github.com/kittors/Lyra/tar.gz/main");
 	// Slashes are legal in branch names (`feat/x`) and must not become path segments.
 	assert.equal(tarballUrl(ref, "feat/x"), "https://codeload.github.com/kittors/Lyra/tar.gz/feat%2Fx");
-});
-
-test("the owner avatar is derived, not stored", () => {
-	assert.equal(ownerAvatar(parseRepo("kittors/Lyra")!), "https://github.com/kittors.png?size=128");
 });
 
 test("a sub-path is kept when it stays inside the checkout", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@lyra/core':
         specifier: workspace:*
         version: link:../core
+      '@lyra/registry-shared':
+        specifier: workspace:*
+        version: link:../registry-shared
       '@modelcontextprotocol/sdk':
         specifier: 1.30.0
         version: 1.30.0(zod@4.4.3)


### PR DESCRIPTION
## 为什么

`version`、`author`、`downloads`、`skillCount`、`clients`——平台自它存在起就在每份索引里发这些，**站点自己的卡片一直在画**，而桌面端的卡片只有一个名字和一句描述。同一个市场的两个视图，对「我们知道多少」给出了不同的答案。

所以这里主要不是新建能力，是把断掉的一段接上。

顺带修了一处真实漂移：本仓的 `registry-shared` 是平台侧的旧副本，连 `clients` 都没有；而 `/v1/index` 也从没输出过这个字段（另一侧 PR 修）——两头都断，客户端因此无从知道一个插件能装进哪些 agent。两份契约现在逐字节一致。

## 改了什么

卡片改成**有边框的一张**，不再是 hover 才显形的行——一格网格读起来才像一排东西而不是一列链接。这也是站点的做法。

新增三样：

**安装记录**（`~/.lyra/installs.json`）。装的时候记下 commit/sha256/version，卸载时删掉。此前装完不留任何来源痕迹，所以「有没有新版本」根本无从判断。

比 `commit` 而不是比版本号——waza 发的是 `0.0.0-30bf9a1`，anthropic-skills 发的是 `0.0.0`，版本号在这些条目上不携带信息。三个都比不了就**沉默**：一个按不掉的更新角标比没有角标更糟，因为按下去装的是同一份字节，角标还在。

用集中账本而不是每个目录一个文件：技能集合没有自己的目录（`moveInto` 把它的技能打散在松散技能中间），所以后者对三种 kind 里的两种成立、第三种要另一套机制。账本不是权威——每个读它的地方都拿磁盘扫描结果去 join，所以手删了目录的陈旧记录是不可见的而不是错的。

**更新**。同一个安装调用加一个 `replace` 标志。安全性和首次安装同源：东西先落到 staging 并验过，目标目录到那时才动，所以失败了手里那份原样还在。uninstall-then-install 中间有一个两头空的窗口。技能集合额外先清旧的散落技能，否则上一版删掉的技能会永远留在技能目录里被每个会话加载。

**卡片上的开关**。规则抽成 `settingsAfterToggle` 和设置页共用——`disabledPlugins: ["*"]` 那段不显然（打开一个得展开通配符原本代表的集合），写两遍会有一遍是错的，且症状一样：开关报告了变更却什么都没变。

## 布局上踩的坑

控件原本绝对定位盖在卡片右上角，文字列留一个固定右内缩去避让。那个数字是对控件宽度的猜测，而且**同时猜错了两个方向**：

- 只有一个 26px 的 ⋯ 时白白让出 96px——量到的：标识行有 260px 而内容要 269px，`agent-browser-cli` 被截成 `agent-browse…`，差九个像素
- 同时出现更新按钮和开关时又不够——118px 的控件挤在 92px 的预留里，重叠 25px

改成点击层沉到底下、控件作为标题行的普通 flex 子元素，就不用预留也不会碰撞。

窄到 360px 时包名只损三个像素、作者先让位，这是 `shrink` 权重定的：包名是要输入的字符串（磁盘目录名、每条命令的参数），半截没用；作者名半截仍可辨认，且不是拿来重打的。

## 验证

在真实组件上量的，八种状态各一张卡：

- 无截断、无重叠、标题完整（360 / 400 / 440 / 860px 四档容器各量一遍）
- 点击命中逐点验过：描述/标题/图标/空白落到卡片，开关落到开关，更新按钮落到更新——这条必须验，因为改了 `pointer-events` 分层
- hover 出 ⋯ 确认；暗色与亮色各看一遍
- 真实线上索引跑完整合并：`version`/`author`/`downloads`/`skillCount`/`serverCount` **10/10 全部有值**；可更新检测双向正确（装旧 commit→true，装当前 commit→false）
- `pnpm check` 全绿：950 个单测，23 个是新的

**未验**：Electron 应用内的完整交互。macOS 的 Apple Events 与屏幕录制授权对话框挡住了窗口，我没有代为授权，所以卡片是在真实组件与真实数据上验的，不是在跑起来的窗口里。

`clients` 徽章要等平台侧 PR 部署后才有数据（线上 `/v1/index` 目前不发这个字段）；其余字段线上已齐，合并即可见。

🤖 Generated with [Claude Code](https://claude.com/claude-code)