### PR TITLE
fix: 修复 Windows 下项目根目录识别

### DIFF
--- a/packages/desktop/electron/file-ops.ts
+++ b/packages/desktop/electron/file-ops.ts
@@ -10,6 +10,30 @@
 import { isAbsolute, relative, resolve } from "node:path";
 
 /**
+ * The deepest root containing `target`, with both sides resolved — or null.
+ *
+ * Returning the deepest match matters when one open project lives inside another: configuration
+ * searches belong to the inner project and must stop at its boundary. Containment is answered by
+ * `path.relative()`, not a string prefix, because Windows paths use backslashes and compare drive
+ * letters case-insensitively.
+ */
+export function containingRoot(target: string, roots: readonly string[]): string | null {
+	if (typeof target !== "string" || target === "" || !isAbsolute(target)) return null;
+	if (target.includes("\0")) return null;
+
+	const full = resolve(target);
+	let deepest: string | null = null;
+	for (const root of roots) {
+		if (!root || !isAbsolute(root) || root.includes("\0")) continue;
+		const base = resolve(root);
+		const rel = relative(base, full);
+		if (rel !== "" && (rel.startsWith("..") || isAbsolute(rel))) continue;
+		if (deepest === null || base.length > deepest.length) deepest = base;
+	}
+	return deepest;
+}
+
+/**
  * The path, normalised, if it lies inside one of the roots — otherwise null.
  *
  * Normalising *before* comparing is the whole job. The check this replaces compared the raw
@@ -24,18 +48,8 @@ import { isAbsolute, relative, resolve } from "node:path";
  * separators (`\` vs `/`) and drive letter casing (`C:` vs `c:`) differ.
  */
 export function resolveInside(target: string, roots: readonly string[]): string | null {
-	if (typeof target !== "string" || target === "" || !isAbsolute(target)) return null;
-	// A NUL truncates the path at the syscall boundary, so the bytes after it would be unchecked.
-	if (target.includes("\0")) return null;
-
-	const full = resolve(target);
-	for (const root of roots) {
-		if (!root || !isAbsolute(root)) continue;
-		const base = resolve(root);
-		const rel = relative(base, full);
-		if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))) return full;
-	}
-	return null;
+	if (containingRoot(target, roots) === null) return null;
+	return resolve(target);
 }
 
 /**

--- a/packages/desktop/electron/main.ts
+++ b/packages/desktop/electron/main.ts
@@ -60,7 +60,7 @@ import {
 	sessions,
 	sideChats,
 } from "./session-hub.ts";
-import { resolveInside } from "./file-ops.ts";
+import { containingRoot, resolveInside } from "./file-ops.ts";
 import { captureLog } from "./screenshot-debug.ts";
 import { registerFilesIpc } from "./ipc/files.ts";
 import { registerFileOpsIpc } from "./ipc/file-ops.ts";
@@ -166,11 +166,8 @@ function projectPath(target: string): string | null {
  * anything walking upward through directories needs in order to know when to stop.
  */
 function projectRoot(target: string): string | null {
-	const resolved = projectPath(target);
-	if (!resolved) return null;
 	const roots = (settings?.projects ?? []).map((project) => project.path);
-	// The longest match, so a project nested inside another resolves to the inner one.
-	return roots.filter((root) => resolved === root || resolved.startsWith(`${root}/`)).sort((a, b) => b.length - a.length)[0] ?? null;
+	return containingRoot(target, roots);
 }
 
 /** The predicate form, for the doorways that only need a yes or no. */

--- a/packages/desktop/test/file-ops.test.ts
+++ b/packages/desktop/test/file-ops.test.ts
@@ -9,7 +9,14 @@
 import assert from "node:assert/strict";
 import { join, resolve } from "node:path";
 import { test } from "node:test";
-import { isDescendant, resolveInside, splitExtension, uniqueName, validateName } from "../electron/file-ops.ts";
+import {
+	containingRoot,
+	isDescendant,
+	resolveInside,
+	splitExtension,
+	uniqueName,
+	validateName,
+} from "../electron/file-ops.ts";
 
 /*
  * Built with `resolve`, not written out.
@@ -52,6 +59,18 @@ test("only absolute paths, and never one carrying a NUL", () => {
 
 test("with no projects open nothing is inside one", () => {
 	assert.equal(resolveInside("/work/app/src/main.ts", []), null);
+});
+
+test("the containing root follows the platform's path rules", () => {
+	assert.equal(containingRoot(join(ROOT, "src", "main.ts"), ROOTS), ROOT);
+	assert.equal(containingRoot(ROOT, ROOTS), ROOT, "the project root belongs to itself");
+	assert.equal(containingRoot(resolve("/work/app-secrets/key.pem"), ROOTS), null);
+});
+
+test("the deepest containing root wins when projects are nested", () => {
+	const inner = join(ROOT, "packages", "desktop");
+	const file = join(inner, "src", "main.ts");
+	assert.equal(containingRoot(file, [ROOT, inner]), inner);
 });
 
 test("a path is not its own descendant, and a sibling prefix is not one either", () => {


### PR DESCRIPTION
## 做了什么

把“一个路径属于哪个已打开项目”的判断提取为可测试的 `containingRoot()`，并让桌面主进程使用它查找格式化配置的项目边界。

补充项目根自身、同名前缀兄弟目录、平台原生路径分隔符和嵌套项目选择最深根目录的测试。

## 为什么

原来的 `resolved.startsWith(`${root}/`)` 只适用于 `/` 分隔符。Windows 路径使用 `\`，所以项目内的嵌套文件无法匹配项目根，向上查找 `.editorconfig` 等格式化配置时会直接返回空。

`path.relative()` 按当前平台的路径和盘符规则判断包含关系，也不会把 `/work/app-secrets` 误判成 `/work/app` 的子目录。

## 怎么验证的

- [x] `pnpm check` 的三部分使用 pnpm 11.9.0 分别执行并通过：lint、5 个 workspace 的 typecheck、全仓单元测试
- [x] 定向 `file-ops` 测试 16/16 通过
- [x] 全仓测试：core 587、desktop 992、agent-cli 7、registry-shared 27 个测试通过，0 失败
- [x] `pnpm --filter @lyra/desktop build` 通过
- [x] 不涉及 UI 样式改动，无需前后截图
- [x] 改了行为的地方有测试盖住

未执行真实 Electron 窗口中的格式化点击验证：本机 Visual Studio 缺少 `node-pty` 构建所需的 Spectre mitigated libraries。路径行为已在 Windows 上通过单元测试覆盖。

## 风险

低。`resolveInside()` 复用同一包含规则，原有路径穿越、兄弟目录和根目录测试继续通过。需要回退时可以直接还原此提交。