### PR TITLE
fix(desktop): 禁止远端 Git 调用弹出凭据窗口

### DIFF
--- a/packages/desktop/electron/git-exec.ts
+++ b/packages/desktop/electron/git-exec.ts
@@ -70,10 +70,22 @@ export function gitEnvironment(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
 }
 
 /**
+ * Remote operations run inside the app, where there is nowhere appropriate to ask for credentials.
+ *
+ * Git's terminal switch does not cover credential helpers: on Windows, Git Credential Manager may
+ * open its own window before Git falls back to a terminal prompt. Both switches are required so a
+ * fetch fails promptly instead of leaving an orphaned credentials dialog behind after its timeout.
+ */
+export function remoteGitEnvironment(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+	return { ...gitEnvironment(base), GIT_TERMINAL_PROMPT: "0", GCM_INTERACTIVE: "0" };
+}
+
+/**
  * Built once. `process.env` does not change under us, and rebuilding it per call would put this
  * work on the path of every `git show` in a two-hundred-file diff.
  */
 const GIT_ENV = gitEnvironment(process.env);
+const REMOTE_GIT_ENV = remoteGitEnvironment(process.env);
 
 export const MAX_FILES = 200;
 export const MAX_BLOB_BYTES = 400_000;
@@ -168,10 +180,9 @@ export interface RemoteResult {
  * without a way to cancel, that is a panel someone is locked inside.
  *
  * **It must not wait for a person.** `GIT_TERMINAL_PROMPT=0` turns git's own prompt into an
- * immediate failure with a clear reason. Worth knowing what this is *not* protecting against:
- * missing credentials never hang here — a process with no tty fails in milliseconds either way.
- * What the variable buys is the wording. Without it git reports `Device not configured`, which
- * describes the tty rather than the problem.
+ * immediate failure with a clear reason, while `GCM_INTERACTIVE=0` prevents Git Credential Manager
+ * from opening a separate GUI prompt first. The latter matters on Windows because killing the git
+ * process on timeout does not necessarily close the credential helper it launched.
  *
  * Deliberately does not set `GIT_ASKPASS`. Pointing it at a helper that answers with nothing makes
  * git complete an authentication attempt using an empty username, and the failure changes from
@@ -187,7 +198,7 @@ export async function runRemote(
 		await execFileAsync("git", args, {
 			cwd,
 			maxBuffer: 32 * 1024 * 1024,
-			env: { ...GIT_ENV, GIT_TERMINAL_PROMPT: "0" },
+			env: REMOTE_GIT_ENV,
 			timeout: timeoutMs,
 			signal,
 		});

--- a/packages/desktop/test/git-environment.test.ts
+++ b/packages/desktop/test/git-environment.test.ts
@@ -16,7 +16,7 @@ import { delimiter, join } from "node:path";
 import { test } from "node:test";
 import { promisify } from "node:util";
 
-import { gitEnvironment } from "../electron/git-exec.ts";
+import { gitEnvironment, remoteGitEnvironment } from "../electron/git-exec.ts";
 
 const exec = promisify(execFile);
 
@@ -43,6 +43,12 @@ test("but the rest of the environment is left alone", () => {
 	const env = gitEnvironment({ HOME: "/Users/someone", LANG: "en_US.UTF-8", PATH: "/usr/bin" });
 	assert.equal(env.HOME, "/Users/someone");
 	assert.equal(env.LANG, "en_US.UTF-8");
+});
+
+test("remote git disables both terminal and credential manager prompts", () => {
+	const env = remoteGitEnvironment({ GIT_TERMINAL_PROMPT: "1", GCM_INTERACTIVE: "1", PATH: process.env.PATH });
+	assert.equal(env.GIT_TERMINAL_PROMPT, "0", "git itself must not wait for a terminal");
+	assert.equal(env.GCM_INTERACTIVE, "0", "GCM must not open a window of its own");
 });
 
 test("the usual install locations are added when they are missing", { skip: process.platform === "win32" }, () => {

--- a/packages/desktop/test/git-remote-exec.test.ts
+++ b/packages/desktop/test/git-remote-exec.test.ts
@@ -91,9 +91,8 @@ test("a refusal comes back as a reason, not as the command that failed", async (
 
 test("a remote that needs a login fails immediately rather than waiting for one", async () => {
 	/*
-	 * `GIT_TERMINAL_PROMPT=0` is what makes this a clean failure with a clear reason. Worth pinning
-	 * that it is *fast*: the widespread assumption is that a GUI process hangs waiting for
-	 * credentials, and the real risk — the one the timeout is for — is the network, not the prompt.
+	 * Git and its credential helper have separate prompt controls. Worth pinning that this is *fast*:
+	 * on Windows, GCM otherwise opens a dialog that can outlive the git process killed by the timeout.
 	 */
 	const { createServer: createHttpServer } = await import("node:http");
 	const server = createHttpServer((_req, res) => {


### PR DESCRIPTION
## 问题

Windows 配置 `credential.helper=manager` 时，`GIT_TERMINAL_PROMPT=0` 只能禁止 Git 自己读取终端，不能阻止 Git Credential Manager 打开独立 GUI。

因此，远端认证回归测试面对 `127.0.0.1:<随机端口>` 的 HTTP 401 响应时会弹出凭据窗口；Git 超时退出后，该窗口还可能继续留在桌面上。

## 修复

- 仅为无人值守的远端 Git 操作同时设置 `GIT_TERMINAL_PROMPT=0` 和 `GCM_INTERACTIVE=0`
- 强制覆盖调用方已有的交互设置，确保应用内操作不会等待用户输入凭据
- 保持普通本地 Git 调用的环境与行为不变
- 增加环境回归断言，并更新 401 远端测试的说明

没有设置空的 AskPass helper，因为那会把“没有凭据”扭曲成“空凭据被拒绝”，影响现有错误分类。

## 验证

- Windows 本机，Git Credential Manager `2.8.0`，系统配置 `credential.helper=manager`
- Git 环境与远端执行定向测试：17 通过、3 个平台跳过、0 失败
- 401 认证用例在 930 ms 内返回；未出现 GCM 窗口，也没有遗留 credential helper 进程
- 全 workspace typecheck 通过
- oxlint：0 warnings / 0 errors

全 workspace 测试中，本机 Core 的外部归档下载用例可能因网络超时失败，与本次 desktop 改动无关，交由 GitHub CI 在标准 runner 上复核。
