### PR TITLE
fix(desktop): 切换会话时保留回到底部意图

### DIFF
--- a/packages/desktop/e2e/scroll-follow-probe.ts
+++ b/packages/desktop/e2e/scroll-follow-probe.ts
@@ -22,7 +22,9 @@
  *      re-raise it;
  *   4. leaving a conversation and returning — by view and by opening another conversation — keeps
  *      the position and does not claim new content that never arrived;
- *   5. the panels that share the hook mount and draw.
+ *   5. switching conversations during the ride back completes the reader's return instead of
+ *      restoring an intermediate position and offering the same button again;
+ *   6. the panels that share the hook mount and draw.
  *
  * And one measurement of a browser fact the design was written against: does `display: none` keep
  * a scroll position? Two comments in this repository disagree, and it is reported rather than
@@ -483,6 +485,29 @@ async function switchingBetweenTwoConversations(): Promise<void> {
 		"在两个对话之间切换后位置还在",
 		Math.abs(back.scrollTop - parked.scrollTop) < 40,
 		`离开前 scrollTop=${parked.scrollTop}，回来后 scrollTop=${back.scrollTop}`,
+	);
+
+	/*
+	 * Start the ride and switch in the same task. That deterministically lands inside the 420ms
+	 * window which made the reported symptom seem random by hand: the old snapshot encoded
+	 * `returning` as detached and kept whichever intermediate scrollTop the last frame had reached.
+	 */
+	await app.evaluate(`(() => {
+		const back = [...document.querySelectorAll("main button")].find((b) => /回到最新|有新内容/.test(b.textContent || ""));
+		const row = [...document.querySelectorAll("aside button, nav button")].find((b) => (b.textContent || "").trim() === ${JSON.stringify(other)});
+		if (back && row) {
+			back.click();
+			row.click();
+		}
+	})()`);
+	await settle(900);
+	await click("第二个对话");
+	await settle(900);
+	const returned = await look();
+	check(
+		"归位动画期间切走，回来后仍完成归位",
+		returned.distance < 4 && !returned.button && returned.unread === 0,
+		`回来后 distance=${returned.distance}，按钮=${returned.button ? "显示" : "隐藏"}，未读=${returned.unread}`,
 	);
 }
 

--- a/packages/desktop/src/components/scroll/follow.ts
+++ b/packages/desktop/src/components/scroll/follow.ts
@@ -31,6 +31,17 @@ export type FollowState =
 	/** A glide back down is in flight. Interruptible — see `nextState`. */
 	| "returning";
 
+/**
+ * The intention that survives a surface swap.
+ *
+ * A returning surface has already been asked to follow the end; the animation is only how that
+ * intention is being applied. Remembering it as detached when another conversation opens during
+ * the glide makes the old surface restore halfway down and offer 「回到最新」 all over again.
+ */
+export function followsAfterRestore(state: FollowState): boolean {
+	return state !== "detached";
+}
+
 /** What a scroller looks like at one instant. The three numbers every decision here is made from. */
 export interface Geometry {
 	scrollTop: number;

--- a/packages/desktop/src/components/scroll/useFollowBottom.ts
+++ b/packages/desktop/src/components/scroll/useFollowBottom.ts
@@ -14,6 +14,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import {
+	followsAfterRestore,
 	isAway,
 	isDegenerate,
 	marker as makeMarker,
@@ -386,6 +387,9 @@ export function useFollowBottom({
 		}
 
 		return () => {
+			// A glide belongs to the outgoing surface. Its intention is saved below, while its frames
+			// must stop before the incoming surface reuses the same state and element refs.
+			cancelAnimationFrame(glide.current);
 			/*
 			 * The position comes from `lastTop`, not from the element.
 			 *
@@ -398,7 +402,7 @@ export function useFollowBottom({
 			 * degenerate measurement, so it is the last position this surface was actually at.
 			 */
 			writeFollow(namespace, surfaceId, {
-				following: state.current === "following",
+				following: followsAfterRestore(state.current),
 				scrollTop: lastTop.current,
 				seen: seen.current,
 			} satisfies FollowSnapshot);

--- a/packages/desktop/test/scroll-follow.test.ts
+++ b/packages/desktop/test/scroll-follow.test.ts
@@ -16,6 +16,7 @@ import {
 	atBottom,
 	distanceToBottom,
 	fitsInView,
+	followsAfterRestore,
 	isAway,
 	isDegenerate,
 	marker,
@@ -195,6 +196,24 @@ test("a swap is decided even from a hidden pane", () => {
 	// has not been laid out yet is ordinary, and it still has to arrive following.
 	const hidden = { scrollTop: 0, scrollHeight: 0, clientHeight: 0 };
 	assert.equal(nextState("detached", { kind: "surface-swap", following: true }, hidden), "following");
+});
+
+test("a return in flight is remembered as an intention to follow", () => {
+	/*
+	 * Opening another conversation during the 420ms glide used to collapse `returning` to false.
+	 * Coming back then restored the intermediate scrollTop as detached and offered the same button
+	 * again, even though the reader had already asked to return.
+	 */
+	assert.equal(followsAfterRestore("following"), true);
+	assert.equal(followsAfterRestore("returning"), true);
+
+	const interrupted = nextState("returning", { kind: "user-scroll", direction: "up" }, at(1800));
+	assert.equal(interrupted, "detached");
+	assert.equal(
+		followsAfterRestore(interrupted),
+		false,
+		"an interrupted return still preserves the reader's position",
+	);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 做了什么

修复点击“回到最新”后，在归位动画期间切换会话，再切回来仍重复显示提示的问题。归位中的会话现在会按“继续跟随底部”的用户意图保存，同时在 surface 切换时停止旧会话的动画帧。

## 为什么

“回到最新”会启动 420ms 的归位动画，内部状态暂时为 returning。原来的保存逻辑只有状态严格等于 following 才记为跟随，因此在这 420ms 内切换会话会把 returning 错误保存成未跟随，并记录动画中间位置。再次打开该会话时便恢复为 detached，重新显示“回到最新”。

这个竞态窗口很短，所以手工操作表现为偶发；新增真实窗口探针将点击归位和切换会话放在同一个事件任务中，可以稳定覆盖该路径。

## 怎么验证的

- [ ] pnpm check（lint + typecheck + test）本地通过
- [ ] 涉及 UI 的改动附了改前/改后截图
- [x] 改了行为的地方有测试盖住

实际验证：

- 全仓 lint：0 warnings、0 errors
- 全 workspace typecheck：通过
- desktop production build：通过
- 滚动状态单测：25/25 通过
- 真实 Electron 滚动探针：全部通过
  - 归位动画期间立即切走并返回：distance=0
  - “回到最新”按钮隐藏
  - unread=0
  - 用户滚轮打断归位后仍保持 detached

没有勾选 pnpm check：本机全量测试仍有与本改动无关的现有失败——3 个 core 外部归档下载测试网络超时，以及 2 个 Windows GCM 非交互认证测试失败；后者已由 #45 单独修复。

没有附前后截图：本次不改变任何 UI 样式或文案，变化只发生在会话切换后的滚动状态；真实窗口探针记录了切回后的实际 DOM 几何和按钮状态。

## 风险

风险集中在用户主动打断归位的场景。回归测试确认：归位中发生滚轮操作时，状态会先变为 detached，切换回来仍保留用户停留的位置，不会被强制拉到底部。