### PR TITLE
fix: 修复新会话默认模型与安卓应用图标

### DIFF
--- a/packages/desktop/e2e/session-scope.test.ts
+++ b/packages/desktop/e2e/session-scope.test.ts
@@ -50,6 +50,17 @@ async function seed(home: string): Promise<void> {
 							supportsImages: false,
 							supportsTools: true,
 						},
+						{
+							id: "relay/quick",
+							providerId: "relay",
+							modelId: "quick",
+							name: "quick",
+							contextWindow: 64000,
+							maxOutputTokens: 4096,
+							supportsThinking: false,
+							supportsImages: false,
+							supportsTools: true,
+						},
 					],
 				},
 			],
@@ -188,6 +199,36 @@ test("the composer shows the level of the conversation on screen", async () => {
 	assert.equal(seen.opened, "高", "the conversation set to high says 高");
 	assert.equal(seen.switched, "关闭", "switching conversations moves the label with it");
 	assert.equal(seen.blank, "中", "a new conversation starts on the app default");
+});
+
+test("a model change finishing late cannot replace a new conversation's default", async () => {
+	const outcome = await ui<{ chip: string | null; appDefault: string | null }>(`
+		const made = await conversation();
+		await openRow(made);
+
+		const modelChip = () => [...document.querySelectorAll('button[aria-haspopup="menu"]')].find((x) =>
+			(x.dataset.lyTip || "").endsWith("上下文"),
+		);
+		const chip = modelChip();
+		if (!chip) throw new Error("model chip not found");
+		click(chip);
+		await wait(200);
+
+		const quick = document.querySelector('[data-model="relay/quick"] button[role="menuitem"]');
+		if (!quick) throw new Error("quick model row not found");
+		// Do not wait for the IPC write: this is the click sequence that used to leak the old meta.
+		click(quick);
+		const fresh = [...document.querySelectorAll("button")].find((b) => label(b).startsWith("新对话"));
+		if (!fresh) throw new Error("新对话 button not found");
+		click(fresh);
+		await wait(500);
+
+		const settings = await window.lyra.settings.get();
+		return { chip: modelChip()?.dataset.lyTip ?? null, appDefault: settings.defaultModelId };
+	`);
+
+	assert.match(String(outcome.chip), /grok-4\.6/, "the blank conversation visibly returns to the default model");
+	assert.equal(outcome.appDefault, "relay/grok-4.6", "the old conversation did not change the app default");
 });
 
 test("changing the level from the menu writes to the conversation, not to the settings", async () => {

--- a/packages/desktop/src/store/turn-slice.ts
+++ b/packages/desktop/src/store/turn-slice.ts
@@ -262,9 +262,31 @@ export function turnSlice(set: Set, get: Get) {
   async setModel(modelId: string, options: { asDefault?: boolean } = {}) {
     const { activeSessionId, settings, meta } = get();
     const midConversation = get().messages.length > 0 && meta?.modelId !== modelId;
-    if (activeSessionId)
-      await window.lyra.agent.setModel(activeSessionId, modelId);
-    if (meta) set({ meta: { ...meta, modelId } });
+    if (activeSessionId) {
+      /*
+       * Paint this conversation's choice before the write crosses IPC.
+       *
+       * Writing it after `await` let the old conversation's meta arrive after `newSession` had
+       * cleared it, making a blank conversation display the model that belonged to the one left
+       * behind. A failed write is rolled back only while that same conversation and choice are
+       * still on screen, so neither path can overwrite a conversation opened in the meantime.
+       */
+      if (meta) set({ meta: { ...meta, modelId } });
+      try {
+        await window.lyra.agent.setModel(activeSessionId, modelId);
+      } catch (cause) {
+        const current = get();
+        if (
+          meta &&
+          current.activeSessionId === activeSessionId &&
+          current.meta?.id === meta.id &&
+          current.meta.modelId === modelId
+        ) {
+          set({ meta });
+        }
+        throw cause;
+      }
+    }
     /*
      * The app default is a separate decision, and used to be made for you.
      *
@@ -275,7 +297,8 @@ export function turnSlice(set: Set, get: Get) {
      */
     if (settings && (options.asDefault || !activeSessionId))
       await get().saveSettings({ ...settings, defaultModelId: modelId });
-    if (midConversation) {
+    // A warning about a conversation already left behind must not appear in the blank one.
+    if (midConversation && get().activeSessionId === activeSessionId) {
       get().notify(
         "已切换模型。之前的推理上下文无法跨模型沿用，接下来的回答可能变差；重开一个对话效果最好。",
         "warn",

--- a/packages/desktop/test/session-thinking.test.ts
+++ b/packages/desktop/test/session-thinking.test.ts
@@ -19,6 +19,7 @@ interface Call {
 const setThinkingCalls: Call[] = [];
 const setModelCalls: Call[] = [];
 const saved: Settings[] = [];
+let setModelGate: Promise<void> | null = null;
 
 /*
  * Enough of a window for the store's own imports.
@@ -43,6 +44,7 @@ const saved: Settings[] = [];
 			},
 			setModel: async (sessionId: string, modelId: string) => {
 				setModelCalls.push({ sessionId, value: modelId });
+				await setModelGate;
 			},
 		},
 		settings: {
@@ -86,7 +88,14 @@ describe("where a change is written", () => {
 		setThinkingCalls.length = 0;
 		setModelCalls.length = 0;
 		saved.length = 0;
-		useApp.setState({ settings: SETTINGS, meta: META, activeSessionId: "s-1", messages: [] });
+		setModelGate = null;
+		useApp.setState({
+			settings: SETTINGS,
+			meta: META,
+			activeSessionId: "s-1",
+			messages: [],
+			workspace: { path: "/project", name: "project", isGitRepo: false, branch: null },
+		});
 	});
 
 	it("a level chosen inside a conversation goes to that conversation only", async () => {
@@ -108,6 +117,23 @@ describe("where a change is written", () => {
 		assert.deepEqual(setModelCalls, [{ sessionId: "s-1", value: "relay/b" }]);
 		assert.equal(saved.length, 0, "`defaultModelId` is a separate decision");
 		assert.equal(useApp.getState().meta?.modelId, "relay/b");
+	});
+
+	it("a late model write cannot leak the old conversation into a new one", async () => {
+		let release!: () => void;
+		setModelGate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+
+		const switching = useApp.getState().setModel("relay/b");
+		assert.equal(useApp.getState().meta?.modelId, "relay/b", "the original conversation updates immediately");
+		await useApp.getState().newSession();
+		assert.equal(useApp.getState().meta, null);
+
+		release();
+		await switching;
+		assert.equal(useApp.getState().meta, null, "the completed write does not restore the previous meta");
+		assert.equal(useApp.getState().settings?.defaultModelId, "relay/a", "the blank conversation uses the app default");
 	});
 
 	it("asking for it explicitly does set the default", async () => {

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -3,6 +3,7 @@
     "name": "Lyra",
     "slug": "lyra",
     "version": "0.1.0",
+    "icon": "../../assets/lyra.png",
     "orientation": "portrait",
     "scheme": "lyra",
     "userInterfaceStyle": "dark",
@@ -20,6 +21,11 @@
     },
     "android": {
       "package": "dev.lyra.app",
+      "icon": "../../assets/lyra.png",
+      "adaptiveIcon": {
+        "foregroundImage": "../../assets/lyra.png",
+        "backgroundColor": "#171717"
+      },
       "edgeToEdgeEnabled": true,
       "usesCleartextTraffic": true
     },


### PR DESCRIPTION
## 变更

- 修复模型切换 IPC 的迟到回写覆盖新建空白会话，使新会话正确显示并使用默认模型
- 将模型切换失败回滚和提示限制在原会话，避免跨会话状态泄漏
- 为 Expo 与 Android 自适应启动器声明 Lyra 应用图标
- 补充模型切换竞态的单元测试和真实 Electron 界面测试

## 验证

- `pnpm lint`
- `pnpm typecheck`
- `node --test ... test/session-thinking.test.ts`（10/10）
- Electron `session-scope.test.ts` 可见行为断言（6/6）
- `expo config --type public` 图标配置解析

全量 pre-push 测试在本机 Windows 仍会被现有的归档超时和 Git 认证超时用例阻断；本 PR 涉及的检查与回归测试均已通过。