### PR TITLE
fix(mobile): keep Android composer above keyboard

### DIFF
--- a/packages/mobile/app/desk.tsx
+++ b/packages/mobile/app/desk.tsx
@@ -1,11 +1,12 @@
 import { useRouter } from "expo-router";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ActivityIndicator, BackHandler, Platform, Pressable, Text, ToastAndroid, View } from "react-native";
+import { ActivityIndicator, BackHandler, Keyboard, Platform, Pressable, Text, ToastAndroid, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { WebView } from "react-native-webview";
 import { StatusBar } from "expo-status-bar";
 import { backPress, type BackState } from "../src/back";
 import { bridgeScript } from "../src/bridge";
+import { keyboardOverlap, type ScreenFrame } from "../src/keyboard";
 import { useMobile } from "../src/store";
 
 /**
@@ -47,6 +48,47 @@ export default function DeskScreen() {
 	 * around rather than patched.
 	 */
 	const webview = useRef<WebView<object>>(null);
+	const webviewHost = useRef<View>(null);
+	const keyboardFrame = useRef<ScreenFrame | null>(null);
+	const [nativeKeyboardInset, setNativeKeyboardInset] = useState(0);
+
+	/*
+	 * Android edge-to-edge windows do not consistently pass IME resizing through a WebView. Measure
+	 * the real screen overlap here: adjustResize produces zero, while an overlaid keyboard shortens
+	 * the WebView without guessing a device- or keyboard-specific height.
+	 */
+	const measureKeyboardOverlap = useCallback(() => {
+		const keyboard = keyboardFrame.current;
+		if (!keyboard) {
+			setNativeKeyboardInset(0);
+			return;
+		}
+		webviewHost.current?.measureInWindow((x, y, width, height) => {
+			if (keyboardFrame.current !== keyboard) return;
+			setNativeKeyboardInset(keyboardOverlap({ x, y, width, height }, keyboard));
+		});
+	}, []);
+
+	useEffect(() => {
+		if (Platform.OS !== "android") return;
+		const shown = Keyboard.addListener("keyboardDidShow", ({ endCoordinates }) => {
+			keyboardFrame.current = {
+				x: endCoordinates.screenX,
+				y: endCoordinates.screenY,
+				width: endCoordinates.width,
+				height: endCoordinates.height,
+			};
+			requestAnimationFrame(measureKeyboardOverlap);
+		});
+		const hidden = Keyboard.addListener("keyboardDidHide", () => {
+			keyboardFrame.current = null;
+			setNativeKeyboardInset(0);
+		});
+		return () => {
+			shown.remove();
+			hidden.remove();
+		};
+	}, [measureKeyboardOverlap]);
 
 	const reload = useCallback(() => {
 		setFailed(null);
@@ -131,10 +173,16 @@ export default function DeskScreen() {
 
 	return (
 		<View
+			ref={webviewHost}
 			className="flex-1"
+			onLayout={measureKeyboardOverlap}
 			// The page's own background, so the safe areas read as part of it rather than as a frame
 			// around it. `bg-shell` was right for exactly one of the two themes.
-			style={{ backgroundColor: theme.shell, paddingTop: insets.top, paddingBottom: insets.bottom }}
+			style={{
+				backgroundColor: theme.shell,
+				paddingTop: insets.top,
+				paddingBottom: Math.max(insets.bottom, nativeKeyboardInset),
+			}}
 		>
 			<StatusBar style={theme.dark ? "light" : "dark"} />
 			<WebView<object>
@@ -192,7 +240,7 @@ export default function DeskScreen() {
 				// makes the whole interface feel detached from the phone.
 				bounces={false}
 				overScrollMode="never"
-				// Keyboard handling belongs to the page's own layout, which already reserves for it.
+				// Native layout handles Android IME overlap; the page still covers visualViewport cases.
 				automaticallyAdjustContentInsets={false}
 				contentInsetAdjustmentBehavior="never"
 				// The app is one origin; anything else is a link someone tapped, and belongs in a

--- a/packages/mobile/src/keyboard.ts
+++ b/packages/mobile/src/keyboard.ts
@@ -1,0 +1,22 @@
+/** A rectangle in screen coordinates, measured in density-independent pixels. */
+export interface ScreenFrame {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+/**
+ * How much of a native view is covered by the software keyboard.
+ *
+ * Android can either resize an edge-to-edge window or put the IME over it, depending on the OS and
+ * WebView combination. Measuring the intersection handles both: a resized view ends above the IME
+ * and returns zero, while an overlaid view reserves only the strip that is actually covered.
+ */
+export function keyboardOverlap(view: ScreenFrame, keyboard: ScreenFrame): number {
+	const horizontalOverlap = Math.min(view.x + view.width, keyboard.x + keyboard.width) - Math.max(view.x, keyboard.x);
+	const verticalOverlap = Math.min(view.y + view.height, keyboard.y + keyboard.height) - Math.max(view.y, keyboard.y);
+	if (horizontalOverlap <= 0 || verticalOverlap <= 0) return 0;
+
+	return Math.min(view.height, Math.max(0, Math.round(view.y + view.height - keyboard.y)));
+}

--- a/packages/mobile/test/keyboard.test.ts
+++ b/packages/mobile/test/keyboard.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { keyboardOverlap, type ScreenFrame } from "../src/keyboard.ts";
+
+const FULL_SCREEN: ScreenFrame = { x: 0, y: 0, width: 430, height: 932 };
+const KEYBOARD: ScreenFrame = { x: 0, y: 570, width: 430, height: 362 };
+
+test("an overlaid keyboard reserves the covered part of the view", () => {
+	assert.equal(keyboardOverlap(FULL_SCREEN, KEYBOARD), 362);
+});
+
+test("adjustResize does not get a second keyboard reservation", () => {
+	const resizedView = { ...FULL_SCREEN, height: KEYBOARD.y };
+	assert.equal(keyboardOverlap(resizedView, KEYBOARD), 0);
+});
+
+test("screen offsets are included in the overlap", () => {
+	const insetView = { x: 0, y: 48, width: 430, height: 884 };
+	assert.equal(keyboardOverlap(insetView, KEYBOARD), 362);
+});
+
+test("a keyboard outside the view does not change its layout", () => {
+	assert.equal(keyboardOverlap(FULL_SCREEN, { ...KEYBOARD, x: 500 }), 0);
+	assert.equal(keyboardOverlap(FULL_SCREEN, { ...KEYBOARD, y: 940 }), 0);
+});
+
+test("a malformed frame cannot reserve more than the whole view", () => {
+	assert.equal(keyboardOverlap(FULL_SCREEN, { x: 0, y: -20, width: 430, height: 952 }), FULL_SCREEN.height);
+});
+
+test("fractional native coordinates produce whole layout pixels", () => {
+	assert.equal(keyboardOverlap(FULL_SCREEN, { ...KEYBOARD, y: 570.4 }), 362);
+});


### PR DESCRIPTION
## Summary

- listen for Android keyboard show and hide events in the native WebView container
- measure the real screen-space overlap between the WebView and the keyboard
- apply only the overlapping bottom inset, avoiding double compensation when `adjustResize` already works
- keep the existing `visualViewport` handling as a fallback for iOS and unusual WebView behavior
- add focused unit tests for keyboard overlap calculations

## Verification

- mobile tests: 64/64 passed
- repository lint: passed with zero warnings
- repository typecheck: passed
- Android arm64 release APK: built successfully
- Android 16 physical device (PLR110): the composer stayed fully above the IME with 72 px clearance
- after hiding the keyboard, the composer returned to the bottom with no residual padding

The full test hook still encounters the existing Core archive-download failures on Windows; all tests and checks related to this change pass.
