### PR TITLE
fix(core): enhance glob and grep tools to extract patterns embedded in description / 增强 glob 与 grep 工具对嵌入模式的容错提取

### DIFF
--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -165,7 +165,7 @@ function escapeRegex(text: string): string {
 /** Extract a glob pattern when the model embeds it in a description string. */
 export function extractPattern(desc: unknown): string {
 	if (typeof desc !== "string" || !desc.trim()) return "";
-	const labeled = desc.match(/(?:pattern|glob|query)[:=\s]+[`'"]?([^`'")\s]+)/i);
+	const labeled = desc.match(/(?:pattern|glob|query)[:=]\s*[`'"]?([^`'")\s]+)/i);
 	if (labeled?.[1]) return labeled[1].replace(/[`'"]+$/, "").trim();
 	const quoted = desc.match(/[`'"]([^`'"]*[*?{}][^`'"]*)[`'"]/);
 	if (quoted?.[1]) return quoted[1].trim();

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -13,6 +13,7 @@ const SKIP_DIRS = new Set([
 
 interface GlobArgs {
 	pattern: string;
+	description?: string;
 	path?: string;
 	limit?: number;
 }
@@ -27,6 +28,7 @@ export const globTool: Tool<GlobArgs> = {
 	parameters: {
 		type: "object",
 		properties: {
+			description: { type: "string", description: "Optional description of what this find operation is doing." },
 			pattern: { type: "string", description: "Glob pattern, relative to the search root." },
 			query: { type: "string", description: "Alias for pattern." },
 			search: { type: "string", description: "Alias for pattern." },
@@ -38,7 +40,7 @@ export const globTool: Tool<GlobArgs> = {
 	},
 	summarize: (args) => {
 		const raw = args as unknown as Record<string, unknown>;
-		const term = String(raw.pattern ?? raw.query ?? raw.search ?? "");
+		const term = String(raw.pattern ?? raw.query ?? raw.search ?? extractPattern(raw.description) ?? "");
 		return term ? `Find ${term}` : "Find";
 	},
 
@@ -50,7 +52,9 @@ export const globTool: Tool<GlobArgs> = {
 				? raw.query
 				: typeof raw.search === "string" && raw.search
 					? raw.search
-					: "";
+					: typeof raw.description === "string"
+						? extractPattern(raw.description)
+						: "";
 
 		const path = typeof raw.path === "string" ? raw.path : typeof raw.dir === "string" ? raw.dir : typeof raw.cwd === "string" ? raw.cwd : undefined;
 
@@ -156,4 +160,16 @@ export function globToRegExp(pattern: string): RegExp {
 
 function escapeRegex(text: string): string {
 	return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Extract a glob pattern when the model embeds it in a description string. */
+export function extractPattern(desc: unknown): string {
+	if (typeof desc !== "string" || !desc.trim()) return "";
+	const labeled = desc.match(/(?:pattern|glob|query)[:=\s]+[`'"]?([^`'")\s]+)/i);
+	if (labeled?.[1]) return labeled[1].replace(/[`'"]+$/, "").trim();
+	const quoted = desc.match(/[`'"]([^`'"]*[*?{}][^`'"]*)[`'"]/);
+	if (quoted?.[1]) return quoted[1].trim();
+	const wildcard = desc.match(/\S*[*?{}][^\s)]*/);
+	if (wildcard?.[0]) return wildcard[0].trim();
+	return "";
 }

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -238,7 +238,7 @@ function formatMatches(lines: string[], args: GrepArgs, limit: number, literal =
 /** Extract a grep regex pattern when the model embeds it in a description string. */
 export function extractGrepPattern(desc: unknown): string {
 	if (typeof desc !== "string" || !desc.trim()) return "";
-	const labeled = desc.match(/(?:pattern|regex|query|search)[:=\s]+[`'"]?([^`'")\s]+)/i);
+	const labeled = desc.match(/(?:pattern|regex|query|search)[:=]\s*[`'"]?([^`'")\s]+)/i);
 	if (labeled?.[1]) return labeled[1].replace(/[`'"]+$/, "").trim();
 	const quoted = desc.match(/[`'"]([^`'"]+)['`"]/);
 	if (quoted?.[1]) return quoted[1].trim();

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -14,6 +14,7 @@ const SKIP_DIRS = new Set([
 
 interface GrepArgs {
 	pattern: string;
+	description?: string;
 	path?: string;
 	glob?: string;
 	case_insensitive?: boolean;
@@ -31,6 +32,7 @@ export const grepTool: Tool<GrepArgs> = {
 	parameters: {
 		type: "object",
 		properties: {
+			description: { type: "string", description: "Optional description of what this search operation is doing." },
 			pattern: { type: "string", description: "Regular expression to search for." },
 			query: { type: "string", description: "Alias for pattern." },
 			search: { type: "string", description: "Alias for pattern." },
@@ -46,7 +48,7 @@ export const grepTool: Tool<GrepArgs> = {
 	},
 	summarize: (args) => {
 		const raw = args as unknown as Record<string, unknown>;
-		const term = String(raw.pattern ?? raw.query ?? raw.search ?? "");
+		const term = String(raw.pattern ?? raw.query ?? raw.search ?? extractGrepPattern(raw.description) ?? "");
 		return term ? `Search "${term}"` : "Search";
 	},
 
@@ -58,7 +60,9 @@ export const grepTool: Tool<GrepArgs> = {
 				? raw.query
 				: typeof raw.search === "string" && raw.search
 					? raw.search
-					: "";
+					: typeof raw.description === "string"
+						? extractGrepPattern(raw.description)
+						: "";
 
 		if (!pattern) return errorResult("`pattern` is required.");
 		const normalizedArgs: GrepArgs = {
@@ -229,4 +233,14 @@ function formatMatches(lines: string[], args: GrepArgs, limit: number, literal =
 		content: [{ type: "text", text: header + shown.join("\n") + footer }],
 		details: { kind: "grep", pattern: args.pattern, count: lines.length, matches: shown, literal },
 	};
+}
+
+/** Extract a grep regex pattern when the model embeds it in a description string. */
+export function extractGrepPattern(desc: unknown): string {
+	if (typeof desc !== "string" || !desc.trim()) return "";
+	const labeled = desc.match(/(?:pattern|regex|query|search)[:=\s]+[`'"]?([^`'")\s]+)/i);
+	if (labeled?.[1]) return labeled[1].replace(/[`'"]+$/, "").trim();
+	const quoted = desc.match(/[`'"]([^`'"]+)['`"]/);
+	if (quoted?.[1]) return quoted[1].trim();
+	return "";
 }

--- a/packages/core/test/tool-aliases.test.ts
+++ b/packages/core/test/tool-aliases.test.ts
@@ -32,3 +32,26 @@ test("symbolTool accepts query and symbol aliases", async () => {
 	const res = await symbolTool.execute({ query: "grepTool", path: testDir } as any, { cwd: testDir, sessionId: "s", state: new Map() });
 	assert.equal(res.isError, undefined);
 });
+
+test("globTool falls back to extracting pattern from description when pattern is missing", async () => {
+	const res = await globTool.execute({ description: "Find security config files (pattern: **/*Security*.java)", path: testDir } as any, { cwd: testDir, sessionId: "s", state: new Map() });
+	assert.equal(res.isError, undefined);
+});
+
+test("globTool extracts quoted pattern or wildcard from description", async () => {
+	const res = await globTool.execute({ description: "Find all *.ts files in directory", path: testDir } as any, { cwd: testDir, sessionId: "s", state: new Map() });
+	assert.equal(res.isError, undefined);
+	assert.match(res.content[0].text, /tool-aliases\.test\.ts/);
+});
+
+test("grepTool falls back to extracting pattern from description when pattern is missing", async () => {
+	const res = await grepTool.execute({ description: "Search for (pattern: grepTool)", path: testDir } as any, { cwd: testDir, sessionId: "s", state: new Map() });
+	assert.equal(res.isError, undefined);
+	assert.match(res.content[0].text, /grepTool/);
+});
+
+test("grepTool extracts quoted pattern from description", async () => {
+	const res = await grepTool.execute({ description: "Search \"grepTool\" in files", path: testDir } as any, { cwd: testDir, sessionId: "s", state: new Map() });
+	assert.equal(res.isError, undefined);
+	assert.match(res.content[0].text, /grepTool/);
+});


### PR DESCRIPTION
### Summary / 概述

**English:**
Some Agent models (such as certain reasoning or customized tool-calling models) tend to embed search patterns inside `description` parameters (e.g., `description: "Find security config files (pattern: **/*Security*.java)"`), leaving `pattern`/`query`/`search` empty and triggering unexpected `` `pattern` is required. `` validation errors.

**中文：**
部分 Agent 模型在调用工具时，惯性将调用意图和匹配规则写在 `description` 属性中（例如 `description: "Find security config files (pattern: **/*Security*.java)"`），导致原本必填的 `pattern` 字段为空，触发工具参数校验报错。

---

### Changes / 变更内容

- **Schema 补充声明**：在 `glob` 与 `grep` 的参数 schema 中显式声明 `description` 属性，适配不同大模型的调用模式。
- **智能容错提取**：引入 `extractPattern` 与 `extractGrepPattern`，当未直接提供 `pattern`/`query`/`search` 时，自动从 `description` 中提取显式声明的模式（如 `pattern: ...`）、引号包裹的通配符/正则或裸模式。
- **单测覆盖**：在 `packages/core/test/tool-aliases.test.ts` 补充单测，确保向后兼容与提取准确性。