### PR TITLE
fix(core): prevent 400 errors from empty assistant messages on aborted turns / 修复中止回合空 assistant 消息引发的 400 报错与注意力引导

### DIFF
--- a/packages/core/src/ai/openai-chat-completions-request.ts
+++ b/packages/core/src/ai/openai-chat-completions-request.ts
@@ -37,10 +37,14 @@ export function toChatCompletionsMessages(systemPrompt: string, messages: Messag
 		if (message.role === "user") {
 			const hasImages = message.content.some((c) => c.type === "image");
 			if (!hasImages) {
-				const text = message.content
+				let text = message.content
 					.filter((c) => c.type === "text")
 					.map((c) => (c.type === "text" ? c.text : ""))
 					.join("\n");
+				const prevMsg = index > 0 ? messages[index - 1] : undefined;
+				if (prevMsg?.role === "assistant" && prevMsg.stopReason === "aborted" && !message.synthetic) {
+					text = `[System note: Your previous response was interrupted by the user to provide new instructions. Abandon the interrupted thought and focus entirely on the latest user request below.]\n\n${text}`;
+				}
 				out.push({ role: "user", content: text });
 			} else {
 				out.push({
@@ -86,8 +90,15 @@ export function toChatCompletionsMessages(systemPrompt: string, messages: Messag
 			}
 
 			const msg: Record<string, unknown> = { role: "assistant" };
-			if (text) msg.content = text;
-			else if (toolCalls.length > 0) msg.content = null;
+			if (text) {
+				msg.content = text;
+			} else if (toolCalls.length > 0) {
+				msg.content = null;
+			} else if (message.stopReason === "aborted") {
+				msg.content = "[Turn interrupted by user]";
+			} else {
+				msg.content = "";
+			}
 			if (toolCalls.length > 0) msg.tool_calls = toolCalls;
 
 			out.push(msg);


### PR DESCRIPTION
### Summary / 概述

**English:**
When a user aborts an in-flight turn, the subsequent prompt serialized an assistant message with empty content and no tool calls, violating upstream OpenAI Chat Completions API schema constraints (causing HTTP 400 `INVALID_ARGUMENT`). Additionally, LLMs often persist in their previous aborted train of thought, ignoring new user instructions sent immediately after the abort.

**中文：**
当用户主动中止（Abort）正在执行的回合时，下一轮请求序列化出的上一轮 assistant 消息既无 `content` 也无 `tool_calls`，违反了各大 LLM 网关/OpenAI Chat Completions 协议校验规则，直接引发 HTTP 400 `INVALID_ARGUMENT` 报错。此外，模型在中断后容易受前序思维惯性影响，忽略用户中断后发送的最新指令。

---

### Changes / 变更内容

- **空消息合规补全**：被用户中断的回合序列化为合法的占位内容（`[Turn interrupted by user]`），彻底杜绝非法空 assistant payload 导致的 400 报错。
- **上下文转向引导**：紧随中断回合的用户消息前自动注入系统提示引导，提示模型抛弃被打断的旧思路，全力聚焦于用户的最新指令。