### PR TITLE
feat(desktop): 导入本机字体文件，用作界面或代码字体

### DIFF
--- a/docs/adr/0021-imported-fonts-never-leave-this-machine.md
+++ b/docs/adr/0021-imported-fonts-never-leave-this-machine.md
@@ -1,0 +1,110 @@
+# ADR-0021：导入的字体不离开这台机器，并排在 CJK 字体之前
+
+- 状态：已采纳
+- 日期：2026-09-09
+- 相关：`packages/desktop/electron/custom-fonts.ts`、`packages/desktop/electron/font-validation.ts`、
+  `packages/desktop/src/features/settings/imported-fonts.ts`、`packages/desktop/src/styles/base.css`、
+  `packages/contract/src/methods.ts`
+
+## 背景
+
+界面字体原本只能从预置的几种里选。用户要用自己的字体——尤其中文字体，因为预置那几种的中文
+是靠 `local()` 借系统字体，不同机器上长得不一样。
+
+「让用户导入一个字体文件」这句需求里藏着四个独立的决定，每一个选错都不是小事：文件从哪来、
+存在哪、怎么送进渲染进程、以及送进去之后排在字体栈的第几位。
+
+## 决定
+
+### 一、路径不过 IPC，只认原生选择框
+
+`fonts.import` 不接受参数。渲染进程说不出「打开哪个文件」，它只能说「让用户挑一个」，主进程
+弹 `dialog.showOpenDialog`（`properties: ["openFile"]`，不允许多选），拿到路径后自己读。
+
+于是「渲染进程被攻破之后能读到哪些文件」这个问题的答案是：一个都读不到。契约测试
+（`packages/contract/test/methods.test.ts`）把这条钉住了——它读 `ipc/fonts.ts` 的源码，检查
+handler 存在、只允许单选、取消时返回 `null`。
+
+`fonts.read` 确实收一个参数，但那是 64 位十六进制的内容哈希，正则挡在最前面，不是路径。
+
+### 二、三个方法都不对手机开放
+
+`fonts.list`、`fonts.import`、`fonts.read` 在契约里全是 `remote: false`。手机通过配对令牌连上
+来的是一个会话，不是这台电脑的文件系统访问权；字体文件是本机文件，配对不该换来读它的能力。
+
+代价是手机上看不到导入的字体。`settings.json` 会同步过去，所以手机拿到的 `uiFont` 里带着一个
+它取不到的 family，靠字体栈后面的 `PingFang SC` 兜底。这是可接受的降级：手机少了一层自定义，
+而不是坏掉。
+
+### 三、按内容寻址，用目录 rename 提交
+
+存储路径是 `userData/fonts/<sha256>/`，里面 `font.bin` 加 `metadata.json`。同一个文件导入两次
+就是同一个 id，不会存两份；先写进临时目录、再 `rename` 成正式目录，所以中断的导入是不可见的，
+而不是一个只写了一半的条目。并发导入同一份内容时 rename 会失败，失败分支去读已有条目。
+
+读回时重新算哈希并与目录名比对：目录名就是内容的摘要，对不上就是这份数据已经不是当初存进去的
+那份了，拒绝比修复更合适。
+
+### 四、送进渲染进程的是 `data:` URL，不是文件路径
+
+渲染进程拿到的是完整的 `data:font/...;base64,...`，没有任何本机路径。
+
+为什么不给路径：给了路径就要开 `file://` 或者再造一个自定义协议，两条都在扩大渲染进程能碰到
+的东西；而字体本来就是要整个读进内存的，省不出流式的好处。
+
+**这条量过**。22.2 MiB 的 `Arial Unicode.ttf` 经 `data:` URL 正常加载，所以 32 MiB 的上限不是
+一句空话。上限本身是这么定的：最大的中日韩字体（思源黑体一个字重约 16 MB）要能进来，同时这个
+数要小到能在主进程里安全地持有两份（原始字节加 base64）。
+
+### 五、容器校验放在存之前，但浏览器才是最后一关
+
+`font-validation.ts` 检查签名与扩展名一致、表目录不越界不重叠、必需表齐全、WOFF2 的 brotli
+流能解开且有界。它**不是**字形消毒器——`shared/custom-fonts.ts` 的注释和 `loadImportedFont`
+的 `await FontFace.load()` 是同一件事的两半。
+
+它的价值是把便宜的问题挡在便宜的地方：越界的偏移、无界的解压、名实不符的扩展名。本机 241 个
+系统字体跑下来只拒了一个 `NISC18030.ttf`，它用 `bhed`/`bdat`/`bloc` 代替 `head`/`glyf`/`loca`，
+是 Apple 的位图字体。
+
+反过来，浏览器拒的比这个多：**macOS 自带的 AppleGothic 和 AppleMyungjo 都过不了 Chromium 的
+消毒器**（`Invalid font data in ArrayBuffer`），因为它们带 Apple 私有的字体表。用户导入这两个
+会失败，而 Chromium 对 `data:` URL 的说法是 `A network error occurred`——一个本地文件不可能有
+网络错误。所以 `installFont` 把 `NetworkError` 单独译成「浏览器拒绝了这个字体文件」，否则用户
+会去查网络。
+
+### 六、导入的字体排在 `Lyra CJK` 之前
+
+`base.css` 的 `body` 现在是：
+
+```css
+font-family: var(--ly-imported-ui-font, var(--ly-script-font, "Lyra CJK")), var(--ly-script-font, "Lyra CJK"),
+  var(--ly-ui-font, var(--font-sans));
+```
+
+`Lyra CJK` 排在配置字体之前是有原因的（见 `base.css` 里那段注释和 `docs/architecture/i18n.md`）：
+它带 CJK 专属的 `unicode-range`，负责中文的字号匹配和全角标点的位置。
+
+但那是在「用户没选过」的前提下成立的。**导入是用户专门去找了一个文件回来**，一个人导入中文
+字体就是想让中文用它；把 `Lyra CJK` 留在前面，等于把他挑的字体用在这一行的英文上、对他真正
+在意的那一半视而不见。
+
+所以只有导入字体能插到它前面，而且 `syncImportedUiFont` 只在浏览器**已经接受**这个 face 之后
+才设 `--ly-imported-ui-font`——加载失败的字体到不了这一行，CJK 那层调整照常生效。
+
+`Lyra CJK` 在栈里出现两次，是刻意的：没导入字体时 `var()` 的兜底解析成它自己，多一个同名条目
+不产生任何代价；导入了字体时，它接住导入字体没覆盖到的 CJK 字形。
+
+## 后果
+
+**代码字体没有对应的变量。** 「应用为代码字体」写进 `--ly-code-font`，而 `markdown.css` 里
+`Lyra CJK` 仍排在它前面，所以导入的等宽字体管拉丁字母，代码块里的中文仍由 `Lyra CJK` 绘制。
+这是有意留下的不对称：代码绝大多数是拉丁字母，而 `Lyra CJK` 的字号匹配对代码块里偶尔出现的
+中文反而更合适。要改的话就是加一个 `--ly-imported-code-font`，按 UI 那条的样子走。
+
+**验证靠 `e2e/imported-font-probe.ts`。** 单元测试证明字节存住了、face 注册了，证明不了
+「窗口画出来的到底是哪个字体」。probe 把每段文字画进 canvas 再哈希像素：宽度单独不够用，CJK
+字形在哪个字体里都是全角，两个完全不同的字体量出来一样宽，只有画出来才分得开。
+
+**这条 ADR 的第五节是踩出来的。** 第一次写 probe 挑了 AppleGothic 当样本字体，跑出来
+`--ly-imported-ui-font` 死活不设——查到最后是浏览器拒收，而不是任何一处代码写错了。选一个
+「系统自带的字体」当测试素材，看起来最安全，恰恰是这次唯一坏掉的那个假设。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,5 +27,6 @@
 | [0018](0018-fuses-not-yet.md) | Electron fuses 暂不启用——配了但验证不了 |
 | [0019](0019-no-virtual-list-yet.md) | 长会话不上虚拟列表——量过了，不需要 |
 | [0020](0020-trajectory-inspector-in-panel.md) | 轨迹时间轴和详情留在面板内 |
+| [0021](0021-imported-fonts-never-leave-this-machine.md) | 导入的字体不离开本机，并排在 CJK 字体之前 |
 
 写一份新的：复制最近一份的结构，编号往下走，加进这张表。

--- a/docs/architecture/i18n.md
+++ b/docs/architecture/i18n.md
@@ -33,6 +33,9 @@ Expo 原生外壳在 `packages/mobile/src/i18n.ts` 中维护配对、扫码、�
 `<html lang>` 还负责选择 CJK 字形。繁体中文、日文与韩文各使用对应的系统字体族，俄文使用
 Inter 的 Cyrillic 与 Cyrillic Extended 子集，避免同一行混入不同字形风格。
 
+只有用户在「外观 → 导入字体」里导入并应用的字体能排在这套字形选择之前，因为那是他专门找来的
+文件；`Lyra CJK` 仍留在它后面，接住导入字体没覆盖到的 CJK 字形。理由见 [ADR-0021](../adr/0021-imported-fonts-never-leave-this-machine.md)。
+
 ## 新增文案
 
 1. 在 `packages/desktop/src/i18n/messages/zh-CN.ts` 增加语义化 key。

--- a/packages/contract/src/methods.ts
+++ b/packages/contract/src/methods.ts
@@ -58,6 +58,11 @@ export const METHODS = {
 		get: { channel: "delivery:get", remote: false, why: "本机文件差异和实现记录" },
 		undo: { channel: "delivery:undo", remote: false, why: "恢复本轮文件，要求本机审阅" },
 	},
+	fonts: {
+		list: { channel: "fonts:list", remote: false, why: "仅本机字体文件，不同步到手机" },
+		import: { channel: "fonts:import", remote: false, why: "仅本机字体文件，由本机原生对话框选择" },
+		read: { channel: "fonts:read", remote: false, why: "仅本机字体文件，不向远端提供字体数据" },
+	},
 	services: {
 		list: { channel: "services:list", remote: false, why: "读取本机进程和监听端口" },
 		stop: { channel: "services:stop", remote: false, why: "停止当前会话拥有的本机进程" },

--- a/packages/contract/test/methods.test.ts
+++ b/packages/contract/test/methods.test.ts
@@ -214,3 +214,21 @@ test("最该挡住的那几样，确实挡住了", () => {
 		assert.equal(method.remote, false, `${path} 不该对手机开放：持有配对令牌不等于拥有这台机器`);
 	}
 });
+
+test("imported fonts remain local and have native IPC handlers", async () => {
+	const handlers = await source("ipc/fonts.ts");
+	const main = await source("main.ts");
+	assert.match(main, /registerFontsIpc\(\)/u);
+	for (const name of ["list", "import", "read"]) {
+		const method = methodFor(`fonts.${name}`);
+		assert.ok(method);
+		assert.equal(method.channel, `fonts:${name}`);
+		assert.equal(method.remote, false);
+		assert.match(method.why ?? "", /本机字体文件/u);
+		assert.equal(REMOTE_METHODS.includes(`fonts.${name}`), false);
+		assert.ok(handlers.includes(`ipcMain.handle("${method.channel}"`));
+	}
+	assert.match(handlers, /properties: \["openFile"\]/u);
+	assert.doesNotMatch(handlers, /multiSelections/u);
+	assert.match(handlers, /if \(result\.canceled \|\| result\.filePaths\.length === 0\) return null/u);
+});

--- a/packages/desktop/e2e/imported-font-probe.ts
+++ b/packages/desktop/e2e/imported-font-probe.ts
@@ -1,0 +1,201 @@
+/* oxlint-disable no-console -- 探针的输出就是它的全部产物 */
+/**
+ * Whether an imported font is the one actually drawing the interface.
+ *
+ * `node --experimental-strip-types e2e/imported-font-probe.ts [font file]`
+ *
+ * The unit tests prove the store keeps the bytes and the loader registers a face. Neither can say
+ * what this asks: after all of that, which physical font did Chromium reach for when it drew the
+ * window. So each sample is drawn three times into a canvas — under the cascade `body` actually
+ * resolves to, under the imported family alone, and under the stack that would be left if nothing
+ * had been imported — and the pixels are hashed. Widths cannot answer this on their own: CJK
+ * glyphs are full-width in every face, so two completely different fonts measure the same and only
+ * the drawing tells them apart.
+ *
+ * Both halves of `base.css` are checked, because they fail in opposite directions. The imported
+ * family has to be reached at all, which is what the whole feature is for; and `Lyra CJK` has to
+ * still be reachable behind it, because putting the imported font first is exactly the kind of
+ * change that silently drops the CJK adjustment for everyone who has not imported anything.
+ *
+ * The second half puts the default stack back through `settings.save`, so the removal travels the
+ * same path it does for a user pressing 只恢复默认字体 — main process, settings event,
+ * `loadSelectedFonts`, `syncImportedUiFont` — rather than being poked into the document here.
+ */
+
+import assert from "node:assert/strict";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { startApp, type RunningApp } from "./app.ts";
+import { CustomFontStore } from "../electron/custom-fonts.ts";
+
+/**
+ * Wide coverage, so its glyphs reach into the range `Lyra CJK` would otherwise claim.
+ *
+ * Apple's own CJK faces cannot be used here even though they are the obvious choice: Chromium's
+ * sanitizer refuses AppleGothic and AppleMyungjo outright — `Invalid font data in ArrayBuffer` —
+ * because of the Apple-specific tables they carry. That refusal is worth knowing about (it is what
+ * the browser will say to a user who imports one) but it makes them useless for measuring anything
+ * past the load. At 22 MiB this one also shows the `data:` URL carrying a real font, not a token.
+ */
+const SOURCE = process.argv[2] ?? "/System/Library/Fonts/Supplemental/Arial Unicode.ttf";
+const PORT = 9733;
+const DEFAULT_UI_FONT_STACK =
+	'"Inter Variable", -apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", sans-serif';
+/** What the CJK samples fall to when no imported family is in front of them. */
+const WITHOUT_IMPORT = '"Lyra CJK", "PingFang SC", "Microsoft YaHei", sans-serif';
+
+const SAMPLES = [
+	{ label: "latin ", text: "Lyra Imported AaBb 123" },
+	{ label: "han   ", text: "中文测试" },
+	{ label: "标点  ", text: "，、。" },
+];
+
+interface Drawn {
+	hash: string;
+	width: number;
+}
+type Variant = "cascade" | "imported" | "without" | "cjk" | "missing";
+interface Reading {
+	stack: string;
+	registered: boolean;
+	importedVar: string;
+	samples: Record<string, Record<Variant, Drawn>>;
+}
+
+let family = "";
+
+async function seed(home: string): Promise<void> {
+	// `main.ts` points userData at `$LYRA_HOME/chromium`, which is where the store will look.
+	const userData = join(home, "chromium");
+	await mkdir(userData, { recursive: true });
+	const font = await new CustomFontStore(userData).importFile(SOURCE);
+	family = font.family;
+	console.log(`导入 ${SOURCE}\n  family=${family}\n  format=${font.format}  size=${font.size} 字节`);
+
+	await writeFile(join(home, "window.json"), JSON.stringify({ width: 1200, height: 860, x: 0, y: 0 }));
+	await writeFile(
+		join(home, "settings.json"),
+		JSON.stringify({
+			version: 1,
+			providers: [],
+			mcpServers: [],
+			projects: [],
+			appearance: { uiFont: `"${family}", "PingFang SC", "Microsoft YaHei", sans-serif` },
+		}),
+	);
+}
+
+function reader(): string {
+	return `(() => {
+		const samples = ${JSON.stringify(SAMPLES)};
+		const canvas = document.createElement("canvas");
+		canvas.width = 1000;
+		canvas.height = 96;
+		const ctx = canvas.getContext("2d");
+		const draw = (stack, text) => {
+			ctx.clearRect(0, 0, canvas.width, canvas.height);
+			ctx.font = "56px " + stack;
+			ctx.textBaseline = "top";
+			ctx.fillStyle = "#000";
+			ctx.fillText(text, 0, 8);
+			const pixels = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+			// The alpha channel alone: the ink is black, so coverage is the whole of the drawing.
+			let hash = 2166136261;
+			for (let at = 3; at < pixels.length; at += 4) {
+				hash ^= pixels[at];
+				hash = Math.imul(hash, 16777619);
+			}
+			return { hash: (hash >>> 0).toString(16), width: Math.round(ctx.measureText(text).width * 100) / 100 };
+		};
+		const stack = getComputedStyle(document.body).fontFamily;
+		const out = {};
+		for (const sample of samples) {
+			out[sample.label] = {
+				cascade: draw(stack, sample.text),
+				imported: draw('"${family}"', sample.text),
+				without: draw(${JSON.stringify(WITHOUT_IMPORT)}, sample.text),
+				// Is Lyra CJK a face on this host at all? Its src is three local() names, and
+				// where none of them is installed the family resolves to nothing and every
+				// conclusion about ordering past it is about a stack entry that was never there.
+				cjk: draw('"Lyra CJK"', sample.text),
+				missing: draw('"Ly Absent Family 4711"', sample.text),
+			};
+		}
+		const root = document.documentElement.style;
+		return {
+			stack,
+			registered: document.fonts.check('13px "${family}"'),
+			importedVar: root.getPropertyValue("--ly-imported-ui-font"),
+			samples: out,
+		};
+	})()`;
+}
+
+/**
+ * Wait for the renderer to settle on an answer before reading it.
+ *
+ * Reading a 15 MB face out of the store, across IPC and through `FontFace.load`, takes longer than
+ * the first paint the harness waits for. Measuring straight away reports the stack as it was on the
+ * way there, which is a real state of the app and not the one being asked about.
+ */
+async function settled(app: RunningApp, expected: boolean): Promise<void> {
+	for (let attempt = 0; attempt < 60; attempt++) {
+		const set = await app.evaluate<boolean>(
+			`!!document.documentElement.style.getPropertyValue("--ly-imported-ui-font")`,
+		);
+		if (set === expected) return;
+		await app.evaluate<null>("new Promise((done) => setTimeout(() => done(null), 100))");
+	}
+	throw new Error(`等了 6 秒，--ly-imported-ui-font 仍然不是「${expected ? "已设置" : "未设置"}」`);
+}
+
+async function measure(app: RunningApp, when: string): Promise<Reading> {
+	const reading = await app.evaluate<Reading>(reader());
+	console.log(`\n${when}`);
+	console.log(`  body 解析出的字体栈：${reading.stack}`);
+	console.log(`  --ly-imported-ui-font=${reading.importedVar || "(未设置)"}`);
+	console.log(`  导入的 FontFace 已注册：${reading.registered}`);
+	for (const sample of SAMPLES) {
+		const drawn = reading.samples[sample.label];
+		const show = (name: Variant) => `${name}=${drawn[name].hash}/${drawn[name].width}px`;
+		console.log(`  ${sample.label} 「${sample.text}」  ${(["cascade", "imported", "without", "cjk", "missing"] as Variant[]).map(show).join("  ")}`);
+	}
+	return reading;
+}
+
+const app = await startApp({ port: PORT, seed });
+try {
+	await settled(app, true);
+	const chosen = await measure(app, "① 选中导入字体");
+	assert.ok(chosen.registered, "启动时读回的导入字体没有注册成 FontFace");
+
+	const importedAt = chosen.stack.indexOf(family);
+	const cjkAt = chosen.stack.indexOf("Lyra CJK");
+	assert.ok(importedAt >= 0, "导入字体没有出现在 body 的字体栈里");
+	assert.ok(cjkAt >= 0, "Lyra CJK 从 body 的字体栈里消失了");
+	assert.ok(importedAt < cjkAt, "导入字体排在 Lyra CJK 后面，CJK 字形永远轮不到它");
+
+	for (const sample of SAMPLES) {
+		const drawn = chosen.samples[sample.label];
+		assert.equal(drawn.cascade.hash, drawn.imported.hash, `${sample.label.trim()} 画出来的不是导入的那个字体`);
+		assert.notEqual(drawn.cascade.hash, drawn.without.hash, `${sample.label.trim()} 有没有导入字体画出来一模一样，这个样本证明不了任何事`);
+	}
+
+	await app.evaluate<null>(`(async () => {
+		const settings = await window.lyra.settings.get();
+		await window.lyra.settings.save({ ...settings, appearance: { ...settings.appearance, uiFont: ${JSON.stringify(DEFAULT_UI_FONT_STACK)} } });
+		return null;
+	})()`);
+	// The renderer reacts to the settings event, not to the call returning.
+	await settled(app, false);
+
+	const plain = await measure(app, "② 通过 settings.save 恢复默认字体");
+	assert.equal(plain.stack.indexOf(family), -1, "恢复默认后导入字体还留在字体栈里");
+	for (const sample of SAMPLES) {
+		const drawn = plain.samples[sample.label];
+		assert.notEqual(drawn.cascade.hash, chosen.samples[sample.label].imported.hash, `${sample.label.trim()} 恢复默认后还在用导入的字体`);
+	}
+	console.log("\n结论：三段文字都由导入字体绘制，CJK 也是；恢复默认后不再由它绘制。");
+} finally {
+	await app.stop();
+}

--- a/packages/desktop/electron/custom-font-files.ts
+++ b/packages/desktop/electron/custom-font-files.ts
@@ -1,0 +1,71 @@
+import { constants } from "node:fs";
+import { lstat, open, realpath } from "node:fs/promises";
+import { dirname, isAbsolute, parse, relative, resolve, sep } from "node:path";
+
+export function hasCode(error: unknown, code: string): boolean {
+	return error instanceof Error && "code" in error && error.code === code;
+}
+
+export async function fontDirectory(path: string): Promise<void> {
+	const stat = await lstat(path);
+	if (!stat.isDirectory() || stat.isSymbolicLink() || relative(resolve(path), await realpath(path)) !== "") {
+		throw new Error("Unsafe font directory: symbolic links and non-directories are not allowed");
+	}
+}
+
+/** The picker grants one regular file, not a symlink or a path through a linked directory. */
+export async function fontSource(path: string): Promise<void> {
+	if (!isAbsolute(path) || path.includes("\0")) throw new Error("Invalid font source path");
+	const root = parse(path).root;
+	let current = root;
+	for (const part of path.slice(root.length).split(sep)) {
+		if (!part || part === "." || part === "..") throw new Error("Invalid font source path");
+		current = resolve(current, part);
+		if ((await lstat(current)).isSymbolicLink()) throw new Error("Unsafe font source: symbolic links are not allowed");
+	}
+}
+
+/** Bound allocation before reading and recheck identity to reject swapped or growing files. */
+export async function readFontFile(path: string, maximum: number): Promise<Buffer> {
+	await fontDirectory(dirname(path));
+	const before = await lstat(path);
+	if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1) throw new Error("Unsafe font file: expected a single-link regular file");
+	if (before.size === 0 || before.size > maximum) throw new Error(`Font file size must be between 1 and ${maximum} bytes`);
+	// O_NONBLOCK avoids hanging if a regular file is replaced by a FIFO before open.
+	const file = await open(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0) | (constants.O_NONBLOCK ?? 0));
+	try {
+		const opened = await file.stat();
+		if (!opened.isFile() || opened.nlink !== 1 || opened.dev !== before.dev || opened.ino !== before.ino || opened.size !== before.size) {
+			throw new Error("Font file changed while opening");
+		}
+		const bytes = Buffer.alloc(before.size + 1);
+		let length = 0;
+		while (length < bytes.length) {
+			const result = await file.read(bytes, length, bytes.length - length, length);
+			if (result.bytesRead === 0) break;
+			length += result.bytesRead;
+		}
+		const after = await file.stat();
+		const visible = await lstat(path);
+		await fontDirectory(dirname(path));
+		if (length !== before.size || after.size !== before.size || after.mtimeMs !== before.mtimeMs || after.ctimeMs !== before.ctimeMs
+			|| visible.isSymbolicLink() || visible.dev !== before.dev || visible.ino !== before.ino || after.nlink !== 1) {
+			throw new Error("Font file changed while reading");
+		}
+		return bytes.subarray(0, length);
+	} finally {
+		await file.close();
+	}
+}
+
+export async function writeFontFile(path: string, bytes: Buffer | string): Promise<void> {
+	await fontDirectory(dirname(path));
+	const file = await open(path, "wx", 0o600);
+	try {
+		await file.writeFile(bytes);
+		await file.sync();
+	} finally {
+		await file.close();
+	}
+	await fontDirectory(dirname(path));
+}

--- a/packages/desktop/electron/custom-fonts.ts
+++ b/packages/desktop/electron/custom-fonts.ts
@@ -1,0 +1,139 @@
+import { createHash } from "node:crypto";
+import { lstat, mkdir, mkdtemp, readdir, realpath, rename, rm } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
+import type { ImportedFont, ImportedFontData } from "../shared/custom-fonts.ts";
+import { fontDirectory, fontSource, hasCode, readFontFile, writeFontFile } from "./custom-font-files.ts";
+import { MAX_FONT_SIZE, validateFont } from "./font-validation.ts";
+
+const FONT_ID = /^[a-f0-9]{64}$/u;
+const METADATA_LIMIT = 4096;
+
+function checkId(id: string): void {
+	if (typeof id !== "string" || !FONT_ID.test(id)) throw new Error("Invalid imported font id");
+}
+
+function digest(bytes: Buffer): string {
+	return createHash("sha256").update(bytes).digest("hex");
+}
+
+function visibleCharacter(character: string): boolean {
+	return character.charCodeAt(0) >= 32 && character.charCodeAt(0) !== 127;
+}
+
+function metadata(value: unknown, id: string): ImportedFont {
+	if (typeof value !== "object" || value === null || !("id" in value) || value.id !== id
+		|| !("name" in value) || typeof value.name !== "string" || value.name.length === 0 || value.name.length > 255
+		|| !Array.from(value.name).every(visibleCharacter)
+		|| !("family" in value) || value.family !== `Lyra Imported ${id}`
+		|| !("format" in value) || (value.format !== "ttf" && value.format !== "otf" && value.format !== "woff" && value.format !== "woff2")
+		|| !("size" in value) || typeof value.size !== "number" || !Number.isSafeInteger(value.size) || value.size < 1 || value.size > MAX_FONT_SIZE) {
+		throw new Error("Invalid imported font metadata");
+	}
+	return { id, name: value.name, family: value.family, format: value.format, size: value.size };
+}
+
+/** No paths enter through IPC; only the native picker can call importFile. */
+export class CustomFontStore {
+	private readonly userData: string;
+
+	constructor(userData: string) {
+		this.userData = userData;
+	}
+
+	private async directory(): Promise<string> {
+		// Canonicalize the trusted app directory so system aliases such as macOS /var remain usable.
+		const base = await realpath(this.userData);
+		if ((await lstat(this.userData)).isSymbolicLink()) throw new Error("Unsafe font user data directory");
+		await fontDirectory(base);
+		const root = join(base, "fonts");
+		try {
+			await mkdir(root, { mode: 0o700 });
+		} catch (error) {
+			if (!hasCode(error, "EEXIST")) throw error;
+		}
+		await fontDirectory(root);
+		return root;
+	}
+
+	private async load(root: string, id: string): Promise<{ font: ImportedFont; bytes: Buffer }> {
+		checkId(id);
+		await fontDirectory(root);
+		const directory = join(root, id);
+		await fontDirectory(directory);
+		const value: unknown = JSON.parse((await readFontFile(join(directory, "metadata.json"), METADATA_LIMIT)).toString("utf8"));
+		const font = metadata(value, id);
+		const bytes = await readFontFile(join(directory, "font.bin"), MAX_FONT_SIZE);
+		if (bytes.length !== font.size || digest(bytes) !== id) throw new Error("Imported font integrity check failed");
+		validateFont(bytes, font.format);
+		return { font, bytes };
+	}
+
+	async list(): Promise<ImportedFont[]> {
+		const root = await this.directory();
+		const fonts: ImportedFont[] = [];
+		for (const entry of await readdir(root)) {
+			// Interrupted transactions are invisible; a committed entry is never partially published.
+			if (!FONT_ID.test(entry)) continue;
+			try {
+				fonts.push((await this.load(root, entry)).font);
+			} catch (error) {
+				throw new Error(`Cannot list imported font ${entry}: stored font is unsafe, missing or corrupt`, { cause: error });
+			}
+		}
+		return fonts.sort((left, right) => left.name.localeCompare(right.name) || left.id.localeCompare(right.id));
+	}
+
+	async read(id: string): Promise<ImportedFontData> {
+		checkId(id);
+		const { font, bytes } = await this.load(await this.directory(), id);
+		return { ...font, data: `data:font/${font.format};base64,${bytes.toString("base64")}` };
+	}
+
+	async importFile(path: string): Promise<ImportedFontData> {
+		await fontSource(path);
+		const bytes = await readFontFile(path, MAX_FONT_SIZE);
+		const format = validateFont(bytes, extname(path));
+		const id = digest(bytes);
+		const root = await this.directory();
+		const target = join(root, id);
+		let existing = false;
+		try {
+			await lstat(target);
+			existing = true;
+		} catch (error) {
+			if (!hasCode(error, "ENOENT")) throw error;
+		}
+		if (existing) {
+			try {
+				return await this.read(id);
+			} catch (error) {
+				// A broken existing entry must not be replaced by an otherwise identical import.
+				if (hasCode(error, "ENOENT")) throw new Error("Imported font entry is incomplete", { cause: error });
+				throw error;
+			}
+		}
+		const name = Array.from(basename(path, extname(path))).filter(visibleCharacter).join("").trim().slice(0, 255) || "Imported font";
+		const font: ImportedFont = { id, name, family: `Lyra Imported ${id}`, format, size: bytes.length };
+		const pending = await mkdtemp(join(root, ".import-"));
+		try {
+			await fontDirectory(pending);
+			await writeFontFile(join(pending, "font.bin"), bytes);
+			await writeFontFile(join(pending, "metadata.json"), JSON.stringify(font));
+			await fontDirectory(root);
+			await fontDirectory(pending);
+			try {
+				// Renaming a complete directory commits the resource and name together. A concurrent
+				// writer cannot replace the winner's nonempty directory, even across store instances.
+				await rename(pending, target);
+			} catch (error) {
+				if (!hasCode(error, "EEXIST") && !hasCode(error, "ENOTEMPTY") && !hasCode(error, "EPERM") && !hasCode(error, "EACCES")) throw error;
+				await this.load(root, id);
+			}
+		} finally {
+			await fontDirectory(root);
+			// Only the transaction's own temporary directory is eligible for cleanup.
+			await rm(pending, { recursive: true, force: true });
+		}
+		return this.read(id);
+	}
+}

--- a/packages/desktop/electron/font-validation.ts
+++ b/packages/desktop/electron/font-validation.ts
@@ -1,0 +1,245 @@
+/**
+ * What a file has to look like before it is allowed to become a `data:` URL in the renderer.
+ *
+ * This is a container check, not a sanitizer. It answers "is this the kind of file it claims to
+ * be, and does its own table of contents describe something that fits inside it" — the questions
+ * whose answers are cheap and whose wrong answers are expensive: an oversized allocation, a table
+ * offset pointing past the end, a brotli stream that expands without bound. The outlines
+ * themselves are the browser's problem, which is why `loadImportedFont` still has to await
+ * `FontFace.load()` and report what it says.
+ *
+ * The extension is checked against the signature rather than trusted. A `.otf` holding TrueType
+ * bytes is refused even though both are fonts: the format is recorded in the store's metadata and
+ * spelt again in the `data:` URL's media type, and a record that disagrees with its contents is
+ * the kind of thing that is discovered much later, by something else.
+ */
+
+import { brotliDecompressSync } from "node:zlib";
+import type { ImportedFont } from "../shared/custom-fonts.ts";
+
+/**
+ * 32 MiB.
+ *
+ * Above the largest fonts anyone actually installs — a full Source Han Sans weight is around 16 MB
+ * — and low enough that the bytes can be held twice (raw, then base64) without the main process
+ * noticing. The store reads with this bound before a byte is parsed, so a file that lies about its
+ * size in a header never gets the chance to be allocated.
+ */
+export const MAX_FONT_SIZE = 32 * 1024 * 1024;
+
+const EXTENSIONS: Record<string, ImportedFont["format"]> = { ttf: "ttf", otf: "otf", woff: "woff", woff2: "woff2" };
+
+const TRUETYPE = 0x00010000;
+/** Apple's older spelling of the same thing; still shipped by some system fonts. */
+const TRUETYPE_APPLE = 0x74727565;
+const CFF = 0x4f54544f;
+
+const REQUIRED = ["cmap", "head", "maxp"];
+
+/**
+ * Only the WOFF2 table indices this file reasons about.
+ *
+ * The full known-tag list is 60-odd entries and every one of them would be written here from
+ * memory. The required-table check needs six, all of them at the low end of the list where the
+ * numbering is not in doubt; anything else becomes an opaque `#n` that still counts for duplicate
+ * detection and is otherwise carried through untouched.
+ */
+const WOFF2_TAGS: Record<number, string> = { 0: "cmap", 1: "head", 4: "maxp", 10: "glyf", 11: "loca", 13: "CFF " };
+const WOFF2_GLYF = 10;
+const WOFF2_LOCA = 11;
+const WOFF2_CUSTOM_TAG = 0x3f;
+
+function invalid(reason: string): never {
+	throw new Error(`Invalid font: ${reason}`);
+}
+
+/** Which container the bytes actually are, regardless of what the file was called. */
+function container(bytes: Buffer): ImportedFont["format"] | undefined {
+	if (bytes.length < 4) return undefined;
+	const signature = bytes.toString("latin1", 0, 4);
+	if (signature === "wOFF") return "woff";
+	if (signature === "wOF2") return "woff2";
+	const version = bytes.readUInt32BE(0);
+	if (version === TRUETYPE || version === TRUETYPE_APPLE) return "ttf";
+	if (version === CFF) return "otf";
+	return undefined;
+}
+
+/**
+ * Enough of a font to be worth showing text in.
+ *
+ * Deliberately short of what the spec calls mandatory: `name`, `post`, `OS/2` and the metrics
+ * tables are all required by OpenType and all absent from fonts that browsers load anyway. These
+ * three plus outlines are the ones whose absence means the file is not a font at all.
+ */
+function requiredTables(flavor: number, tags: Set<string>): void {
+	for (const tag of REQUIRED) if (!tags.has(tag)) invalid(`missing ${tag} table`);
+	const outlines = flavor === CFF ? ["CFF ", "CFF2"].some((tag) => tags.has(tag)) : ["glyf", "loca"].every((tag) => tags.has(tag));
+	if (!outlines) invalid(flavor === CFF ? "missing CFF outlines" : "missing glyf/loca outlines");
+}
+
+/** Two tables may abut but not share a byte; a font that overlaps them is describing two things at once. */
+function withoutOverlap(spans: Array<[number, number]>): void {
+	const sorted = [...spans].sort((left, right) => left[0] - right[0]);
+	for (let index = 1; index < sorted.length; index++) {
+		if (sorted[index][0] < sorted[index - 1][1]) invalid("tables overlap");
+	}
+}
+
+function checkSfnt(bytes: Buffer): void {
+	if (bytes.length < 12) invalid("truncated header");
+	const flavor = bytes.readUInt32BE(0);
+	const count = bytes.readUInt16BE(4);
+	const directoryEnd = 12 + count * 16;
+	if (count === 0 || directoryEnd > bytes.length) invalid("the table directory does not fit in the file");
+
+	const tags = new Set<string>();
+	const spans: Array<[number, number]> = [];
+	for (let index = 0; index < count; index++) {
+		const record = 12 + index * 16;
+		const tag = bytes.toString("latin1", record, record + 4);
+		const offset = bytes.readUInt32BE(record + 8);
+		const length = bytes.readUInt32BE(record + 12);
+		// Both fields are unsigned 32-bit, so the sum is exact in a double and cannot wrap.
+		if (offset < directoryEnd || offset + length > bytes.length) invalid(`table ${tag} lies outside the file`);
+		if (tags.has(tag)) invalid(`duplicate ${tag} table`);
+		tags.add(tag);
+		spans.push([offset, offset + length]);
+	}
+	withoutOverlap(spans);
+	requiredTables(flavor, tags);
+}
+
+function checkWoff(bytes: Buffer): void {
+	if (bytes.length < 44) invalid("truncated header");
+	const flavor = bytes.readUInt32BE(4);
+	const declared = bytes.readUInt32BE(8);
+	const count = bytes.readUInt16BE(12);
+	const sfntSize = bytes.readUInt32BE(16);
+	const directoryEnd = 44 + count * 20;
+	if (count === 0 || directoryEnd > bytes.length) invalid("the table directory does not fit in the file");
+	if (declared > bytes.length) invalid("the declared length is larger than the file");
+	if (sfntSize > MAX_FONT_SIZE) invalid("the decompressed font would exceed 32 MiB");
+
+	const tags = new Set<string>();
+	const spans: Array<[number, number]> = [];
+	for (let index = 0; index < count; index++) {
+		const entry = 44 + index * 20;
+		const tag = bytes.toString("latin1", entry, entry + 4);
+		const offset = bytes.readUInt32BE(entry + 4);
+		const stored = bytes.readUInt32BE(entry + 8);
+		const original = bytes.readUInt32BE(entry + 12);
+		// A stored table is written uncompressed and both lengths agree; deflate never grows one.
+		if (original > MAX_FONT_SIZE || stored > original) invalid(`table ${tag} declares an impossible length`);
+		if (offset < directoryEnd || offset + stored > bytes.length) invalid(`table ${tag} lies outside the file`);
+		if (tags.has(tag)) invalid(`duplicate ${tag} table`);
+		tags.add(tag);
+		spans.push([offset, offset + stored]);
+	}
+	withoutOverlap(spans);
+	requiredTables(flavor, tags);
+}
+
+/**
+ * WOFF2's variable-width length, which is where a table directory can lie cheaply.
+ *
+ * Five bytes at most, no leading `0x80` — the spec forbids the padded spelling so that one length
+ * has one encoding — and the running value is bounded before each shift so a long sequence cannot
+ * quietly become a small number.
+ */
+function readBase128(bytes: Buffer, cursor: { at: number }): number {
+	let value = 0;
+	for (let byte = 0; byte < 5; byte++) {
+		if (cursor.at >= bytes.length) invalid("truncated table directory");
+		const digit = bytes[cursor.at++];
+		if (byte === 0 && digit === 0x80) invalid("a padded length in the table directory");
+		if (value > 0x01ffffff) invalid("a length in the table directory exceeds 32 bits");
+		value = value * 128 + (digit & 0x7f);
+		if ((digit & 0x80) === 0) return value;
+	}
+	invalid("a length in the table directory is longer than five bytes");
+}
+
+/** Bounded so a small file cannot ask for an unbounded allocation on the main process. */
+function decompress(compressed: Buffer): Buffer {
+	try {
+		return brotliDecompressSync(compressed, { maxOutputLength: MAX_FONT_SIZE });
+	} catch (cause) {
+		throw new Error("Invalid font: the compressed table stream could not be read", { cause });
+	}
+}
+
+function checkWoff2(bytes: Buffer): void {
+	if (bytes.length < 48) invalid("truncated header");
+	const flavor = bytes.readUInt32BE(4);
+	const declared = bytes.readUInt32BE(8);
+	const count = bytes.readUInt16BE(12);
+	const sfntSize = bytes.readUInt32BE(16);
+	const compressedSize = bytes.readUInt32BE(20);
+	if (count === 0) invalid("the font declares no tables");
+	if (declared > bytes.length) invalid("the declared length is larger than the file");
+	if (sfntSize > MAX_FONT_SIZE) invalid("the decompressed font would exceed 32 MiB");
+
+	const cursor = { at: 48 };
+	const tags = new Set<string>();
+	let expected = 0;
+	for (let index = 0; index < count; index++) {
+		if (cursor.at >= bytes.length) invalid("truncated table directory");
+		const flags = bytes[cursor.at++];
+		const known = flags & 0x3f;
+		let tag: string;
+		if (known === WOFF2_CUSTOM_TAG) {
+			if (cursor.at + 4 > bytes.length) invalid("truncated table directory");
+			tag = bytes.toString("latin1", cursor.at, cursor.at + 4);
+			cursor.at += 4;
+		} else {
+			tag = WOFF2_TAGS[known] ?? `#${known}`;
+		}
+		const original = readBase128(bytes, cursor);
+		/*
+		 * Which version means "left alone" is not the same for every table: glyf and loca have a
+		 * transform defined, so 3 is their null version, while everything else has none and 0 is.
+		 * A transformed table carries a second length, and reading the directory past that point
+		 * depends on getting this right.
+		 */
+		const version = flags >> 6;
+		const transformed = known === WOFF2_GLYF || known === WOFF2_LOCA ? version !== 3 : version !== 0;
+		const length = transformed ? readBase128(bytes, cursor) : original;
+		if (original > MAX_FONT_SIZE || length > MAX_FONT_SIZE) invalid(`table ${tag} declares an impossible length`);
+		if (tags.has(tag)) invalid(`duplicate ${tag} table`);
+		tags.add(tag);
+		expected += length;
+		if (expected > MAX_FONT_SIZE) invalid("the decompressed tables would exceed 32 MiB");
+	}
+
+	if (cursor.at + compressedSize > bytes.length) invalid("the compressed stream lies outside the file");
+	// The tables are stored back to back with no padding, so the stream is exactly their total.
+	if (decompress(bytes.subarray(cursor.at, cursor.at + compressedSize)).length < expected) {
+		invalid("the compressed stream is shorter than the tables it declares");
+	}
+	requiredTables(flavor, tags);
+}
+
+/**
+ * Check the bytes against the name they arrived under, and answer with the format.
+ *
+ * `extension` is whatever the picker gave — `.TTF` as readily as `ttf` — because the two callers
+ * are the import path, which has a filename, and the load path, which has the format recorded when
+ * that file was first accepted.
+ */
+export function validateFont(bytes: Buffer, extension: string): ImportedFont["format"] {
+	// First, before anything reads a header: the size is the one bound that is not self-reported.
+	if (bytes.length > MAX_FONT_SIZE) throw new Error("Font file must not exceed 32 MiB");
+	if (bytes.length === 0) invalid("the file is empty");
+
+	const claimed = EXTENSIONS[extension.replace(/^\./u, "").toLowerCase()];
+	if (!claimed) invalid(`${extension || "a name with no extension"} is not a font extension this app accepts`);
+	const actual = container(bytes);
+	if (!actual) invalid("the file does not begin with a font signature");
+	if (actual !== claimed) invalid(`the file is ${actual}, not the ${claimed} its name claims`);
+
+	if (claimed === "woff") checkWoff(bytes);
+	else if (claimed === "woff2") checkWoff2(bytes);
+	else checkSfnt(bytes);
+	return claimed;
+}

--- a/packages/desktop/electron/ipc-types.ts
+++ b/packages/desktop/electron/ipc-types.ts
@@ -59,6 +59,8 @@ import type { UsageScan } from "./usage-scan.ts";
 export type { DocumentKind } from "../shared/document-kind.ts";
 export type { OpenTarget } from "./open-targets.ts";
 import type { OpenTarget } from "./open-targets.ts";
+import type { ImportedFont, ImportedFontData } from "../shared/custom-fonts.ts";
+export type { ImportedFont, ImportedFontData } from "../shared/custom-fonts.ts";
 
 export type UpdatePhase = DownloadPhase;
 
@@ -203,6 +205,11 @@ export interface LyraApi {
 	 * from how much room it has.
 	 */
 	host?: "desktop" | "mobile";
+	fonts: {
+		list(): Promise<ImportedFont[]>;
+		import(): Promise<ImportedFontData | null>;
+		read(id: string): Promise<ImportedFontData>;
+	};
 	settings: {
 		get(): Promise<Settings>;
 		save(settings: Settings): Promise<Settings>;

--- a/packages/desktop/electron/ipc/fonts.ts
+++ b/packages/desktop/electron/ipc/fonts.ts
@@ -1,0 +1,19 @@
+import { app, dialog, ipcMain } from "electron";
+import { CustomFontStore } from "../custom-fonts.ts";
+import { getWindow } from "../window.ts";
+
+export function registerFontsIpc(): void {
+	const fonts = new CustomFontStore(app.getPath("userData"));
+	ipcMain.handle("fonts:list", () => fonts.list());
+	ipcMain.handle("fonts:read", (_event, id: string) => fonts.read(id));
+	ipcMain.handle("fonts:import", async () => {
+		const window = getWindow();
+		if (!window) return null;
+		const result = await dialog.showOpenDialog(window, {
+			properties: ["openFile"],
+			filters: [{ name: "Fonts", extensions: ["ttf", "otf", "woff", "woff2"] }],
+		});
+		if (result.canceled || result.filePaths.length === 0) return null;
+		return fonts.importFile(result.filePaths[0]);
+	});
+}

--- a/packages/desktop/electron/main.ts
+++ b/packages/desktop/electron/main.ts
@@ -65,6 +65,7 @@ import { captureLog } from "./screenshot-debug.ts";
 import { registerFilesIpc } from "./ipc/files.ts";
 import { registerFileOpsIpc } from "./ipc/file-ops.ts";
 import { registerFormatIpc } from "./ipc/format.ts";
+import { registerFontsIpc } from "./ipc/fonts.ts";
 import { rescueLegacyWorkspaces } from "./scratch.ts";
 import { applySettings, loadAppSettings, onSettingsChanged } from "./app-settings.ts";
 import { registerServicesIpc } from "./ipc/services.ts";
@@ -728,6 +729,7 @@ function registerIpc(): void {
 	registerFilesIpc({ projectRoots: () => (settings?.projects ?? []).map((project) => project.path) });
 	registerFileOpsIpc({ projectPath });
 	registerFormatIpc({ projectPath, projectRoot });
+	registerFontsIpc();
 
 	registerTerminalIpc({ terminals, spawnPty, projectPath, insideAProject, window: () => getWindow() });
 	registerUpdateIpc();

--- a/packages/desktop/shared/custom-fonts.ts
+++ b/packages/desktop/shared/custom-fonts.ts
@@ -1,0 +1,13 @@
+export interface ImportedFont {
+	id: string;
+	name: string;
+	family: string;
+	format: "ttf" | "otf" | "woff" | "woff2";
+	size: number;
+}
+
+/** Container checks cannot validate every outline; callers must also await FontFace.load(). */
+export interface ImportedFontData extends ImportedFont {
+	/** A complete data:font/...;base64 URL, never a local filesystem path. */
+	data: string;
+}

--- a/packages/desktop/src/app/App.tsx
+++ b/packages/desktop/src/app/App.tsx
@@ -70,7 +70,7 @@ const SettingsShell = lazy(() =>
 );
 import { useOpenFile } from "../store/openFile.ts";
 import { useTerminalPrewarm } from "../features/terminal/index.ts";
-import { applyAppearance, watchSystemTheme } from "../features/settings/index.ts";
+import { applyAppearance, loadSelectedFonts, watchSystemTheme } from "../features/settings/index.ts";
 import { bridge } from "../services/index.ts";
 import { I18nProvider, useI18n } from "../i18n/index.ts";
 
@@ -90,9 +90,18 @@ export function App() {
 	useProjectFiles();
 
 	const appearance = useApp((s) => s.settings?.appearance);
+	const uiFont = appearance?.uiFont;
+	const codeFont = appearance?.codeFont;
 	useEffect(() => {
 		if (appearance) applyAppearance(appearance);
 	}, [appearance]);
+	useEffect(() => {
+		if (!uiFont || !codeFont) return;
+		void loadSelectedFonts(uiFont, codeFont).catch((cause: unknown) => {
+			const detail = cause instanceof Error ? cause.message : String(cause);
+			useApp.getState().notify(`所选字体加载失败：${detail}`, "error");
+		});
+	}, [uiFont, codeFont]);
 	useEffect(() => watchSystemTheme(() => useApp.getState().settings?.appearance ?? appearance!), [appearance]);
 
 	/*

--- a/packages/desktop/src/features/settings/AppearanceSettings.tsx
+++ b/packages/desktop/src/features/settings/AppearanceSettings.tsx
@@ -6,6 +6,7 @@ import { findCodeTheme, LIGHT_CODE_THEMES, DARK_CODE_THEMES } from "../../lib/co
 import { CodeAppearancePreview } from "./CodeAppearancePreview.tsx";
 import { CODE_DEFAULTS } from "./code-defaults.ts";
 import { CODE_FONTS, fontAvailable, matchCodeFont } from "./code-fonts.ts";
+import { ImportedFontsSettings } from "./ImportedFontsSettings.tsx";
 import {
 	CONTENT_DEFAULT,
 	CONTENT_FILL,
@@ -176,6 +177,8 @@ export function AppearanceSettings() {
 					}
 				/>
 			</Card>
+
+			<ImportedFontsSettings />
 
 			{/*
 			 * The heading, with a way back to where it started.

--- a/packages/desktop/src/features/settings/ImportedFontsSettings.tsx
+++ b/packages/desktop/src/features/settings/ImportedFontsSettings.tsx
@@ -1,0 +1,220 @@
+import type { ImportedFont, ImportedFontData } from "../../../shared/custom-fonts.ts";
+import { useEffect, useState } from "react";
+import { Download } from "lucide-react";
+import { useApp } from "../../store/index.ts";
+import { available, bridge, onPhone } from "../../services/index.ts";
+import { Card, EmptyHint, GhostButton, PrimaryButton, SectionTitle } from "./controls.tsx";
+import { CODE_DEFAULTS } from "./code-defaults.ts";
+import {
+	DEFAULT_UI_FONT_STACK,
+	importedFontId,
+	importedUiFontStack,
+	loadImportedFont,
+	syncImportedUiFont,
+} from "./imported-fonts.ts";
+
+function formatSize(size: number): string {
+	return size < 1024 * 1024 ? `${Math.ceil(size / 1024)} KB` : `${(size / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function codeFontStack(family: string): string {
+	return `"${family}", ${CODE_DEFAULTS.codeFont}`;
+}
+
+export function ImportedFontsSettings() {
+	const settings = useApp((state) => state.settings);
+	const saveSettings = useApp((state) => state.saveSettings);
+	const [fonts, setFonts] = useState<ImportedFont[]>([]);
+	const [previewFont, setPreviewFont] = useState<ImportedFont | null>(null);
+	const [previewData, setPreviewData] = useState<ImportedFontData | null>(null);
+	const [busy, setBusy] = useState<"list" | "import" | "select" | "ui" | "code" | "reset" | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const phone = onPhone();
+	const fontsAvailable =
+		!phone && available("fonts", "list") && available("fonts", "import") && available("fonts", "read");
+	/*
+	 * The two stacks, not the settings object they came out of.
+	 *
+	 * Every save replaces `settings`, so an effect that depends on it re-reads the store each time
+	 * the accent or the theme moves. These two strings are the only thing the listing cares about,
+	 * and naming them here is also what lets the dependency array say what the body actually uses.
+	 */
+	const uiFont = settings?.appearance.uiFont;
+	const codeFont = settings?.appearance.codeFont;
+
+	useEffect(() => {
+		if (!fontsAvailable || uiFont === undefined || codeFont === undefined) return;
+		let current = true;
+		setBusy("list");
+		void bridge.fonts
+			.list()
+			.then((items) => {
+				if (!current) return;
+				setFonts(items);
+				const selectedId = importedFontId(uiFont) ?? importedFontId(codeFont);
+				setPreviewFont(items.find((font) => font.id === selectedId) ?? null);
+			})
+			.catch((cause: unknown) => {
+				if (!current) return;
+				const detail = cause instanceof Error ? cause.message : String(cause);
+				setError(`读取导入字体失败：${detail}`);
+				useApp.getState().notify(`读取导入字体失败：${detail}`, "error");
+			})
+			.finally(() => {
+				if (current) setBusy(null);
+			});
+		return () => {
+			current = false;
+		};
+	}, [fontsAvailable, uiFont, codeFont]);
+
+	if (phone || !settings) return null;
+	const appearance = settings.appearance;
+
+	const showError = (label: string, cause: unknown) => {
+		const detail = cause instanceof Error ? cause.message : String(cause);
+		const message = `${label}：${detail}`;
+		setError(message);
+		useApp.getState().notify(message, "error");
+	};
+
+	const readForPreview = async (font: ImportedFont): Promise<ImportedFontData> => {
+		if (previewData?.id === font.id) return previewData;
+		const data = await bridge.fonts.read(font.id);
+		await loadImportedFont(data);
+		setPreviewData(data);
+		return data;
+	};
+
+	const selectFont = async (font: ImportedFont) => {
+		setBusy("select");
+		setError(null);
+		try {
+			await readForPreview(font);
+			setPreviewFont(font);
+		} catch (cause) {
+			showError("字体预览加载失败", cause);
+		} finally {
+			setBusy(null);
+		}
+	};
+
+	const importFont = async () => {
+		setBusy("import");
+		setError(null);
+		try {
+			const data = await bridge.fonts.import();
+			if (!data) return;
+			await loadImportedFont(data);
+			setFonts((current) => [data, ...current.filter((font) => font.id !== data.id)]);
+			setPreviewData(data);
+			setPreviewFont(data);
+		} catch (cause) {
+			showError("字体导入失败", cause);
+		} finally {
+			setBusy(null);
+		}
+	};
+
+	const applyFont = async (target: "ui" | "code") => {
+		if (!previewFont) return;
+		setBusy(target);
+		setError(null);
+		try {
+			const font = await readForPreview(previewFont);
+			const stack = target === "ui" ? importedUiFontStack(font.family) : codeFontStack(font.family);
+			await saveSettings({
+				...settings,
+				appearance: { ...appearance, [target === "ui" ? "uiFont" : "codeFont"]: stack },
+			});
+			if (target === "ui") syncImportedUiFont(stack);
+		} catch (cause) {
+			showError(target === "ui" ? "应用 UI 字体失败" : "应用代码字体失败", cause);
+		} finally {
+			setBusy(null);
+		}
+	};
+
+	const resetFonts = async () => {
+		setBusy("reset");
+		setError(null);
+		try {
+			await saveSettings({
+				...settings,
+				appearance: {
+					...appearance,
+					uiFont: DEFAULT_UI_FONT_STACK,
+					codeFont: CODE_DEFAULTS.codeFont,
+				},
+			});
+			syncImportedUiFont(DEFAULT_UI_FONT_STACK);
+		} catch (cause) {
+			showError("恢复默认字体失败", cause);
+		} finally {
+			setBusy(null);
+		}
+	};
+
+	return (
+		<>
+			<div className="flex items-baseline justify-between">
+				<SectionTitle>导入字体</SectionTitle>
+				<GhostButton onClick={() => void resetFonts()} disabled={busy !== null}>只恢复默认字体</GhostButton>
+			</div>
+			<Card className="mb-8" data-imported-fonts>
+				<div className="flex items-center justify-between gap-4 border-b border-line-soft px-4 py-3">
+					<div className="min-w-0">
+						<p className="text-label font-medium text-ink">本机字体文件</p>
+						<p className="mt-0.5 text-caption text-ink-muted">TTF、OTF、WOFF 或 WOFF2，仅保存在这台电脑</p>
+					</div>
+					<PrimaryButton onClick={() => void importFont()} disabled={!fontsAvailable || busy !== null}>
+						<span className="flex items-center gap-1.5"><Download size={13} />{busy === "import" ? "导入中…" : "导入字体"}</span>
+					</PrimaryButton>
+				</div>
+
+				{!fontsAvailable ? (
+					<EmptyHint>当前桌面环境没有提供本机字体导入能力。</EmptyHint>
+				) : fonts.length === 0 ? (
+					<EmptyHint>{busy === "list" ? "正在读取已导入字体…" : "还没有导入字体。"}</EmptyHint>
+				) : (
+					<div className="border-b border-line-soft p-2">
+						{fonts.map((font) => (
+							<button
+								key={font.id}
+								type="button"
+								aria-pressed={previewFont?.id === font.id}
+								data-imported-font-id={font.id}
+								onClick={() => void selectFont(font)}
+								disabled={busy !== null}
+								className={`flex w-full items-center justify-between gap-3 rounded-[8px] px-3 py-2 text-left transition-colors ${
+									previewFont?.id === font.id ? "bg-accent-soft text-ink" : "text-ink-muted hover:bg-hover hover:text-ink"
+								}`}
+							>
+								<span className="min-w-0 truncate text-label font-medium">{font.name}</span>
+								<span className="shrink-0 text-caption uppercase text-ink-faint">{font.format} · {formatSize(font.size)}</span>
+							</button>
+						))}
+					</div>
+				)}
+
+				<div className="px-4 py-4">
+					<p className="mb-2 text-caption text-ink-muted">中文标点与中英混排预览</p>
+					<p
+						lang="zh-CN"
+						data-imported-font-preview
+						className="rounded-[8px] border border-line-soft bg-surface px-4 py-4 text-[17px] leading-relaxed text-ink"
+						style={{ fontFamily: previewFont ? importedUiFontStack(previewFont.family) : appearance.uiFont }}
+					>
+						“你好，Lyra！”——中文标点 AaBb 123，中英 Mixed 排版。
+					</p>
+					<div className="mt-3 flex flex-wrap items-center gap-2">
+						<PrimaryButton onClick={() => void applyFont("ui")} disabled={!previewFont || busy !== null}>应用为 UI 字体</PrimaryButton>
+						<GhostButton onClick={() => void applyFont("code")} disabled={!previewFont || busy !== null}>应用为代码字体</GhostButton>
+						{previewFont && <span className="text-caption text-ink-faint">当前预览：{previewFont.name}</span>}
+					</div>
+					{error && <p role="alert" className="mt-3 text-caption text-danger">{error}</p>}
+				</div>
+			</Card>
+		</>
+	);
+}

--- a/packages/desktop/src/features/settings/imported-fonts.ts
+++ b/packages/desktop/src/features/settings/imported-fonts.ts
@@ -1,0 +1,102 @@
+import type { ImportedFontData } from "../../../shared/custom-fonts.ts";
+import { bridge, onPhone } from "../../services/index.ts";
+
+const IMPORTED_FAMILY = /Lyra Imported ([a-f0-9]{64})(?![a-f0-9])/u;
+const loadingFonts = new Map<string, Promise<void>>();
+const loadedFamilies = new Map<string, string>();
+let selectionVersion = 0;
+
+export const DEFAULT_UI_FONT_STACK =
+	'"Inter Variable", -apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", sans-serif';
+
+export function importedUiFontStack(family: string): string {
+	return `"${family}", "PingFang SC", "Microsoft YaHei", sans-serif`;
+}
+
+export function importedFontId(stack: string): string | undefined {
+	return IMPORTED_FAMILY.exec(stack)?.[1];
+}
+
+async function installFont(font: ImportedFontData): Promise<void> {
+	if (typeof FontFace === "undefined") throw new Error("当前渲染环境不支持加载自定义字体");
+
+	try {
+		const face = new FontFace(font.family, `url("${font.data}")`);
+		const loaded = await face.load();
+		if (loaded.status !== "loaded") throw new Error(`FontFace 状态为 ${loaded.status}`);
+		document.fonts.add(loaded);
+		loadedFamilies.set(font.id, font.family);
+	} catch (cause) {
+		/*
+		 * A data: URL cannot have a network problem, but that is what the browser calls this.
+		 *
+		 * Chromium answers `NetworkError: A network error occurred` for any face its sanitizer
+		 * refuses, and it refuses more than corrupt files: AppleGothic and AppleMyungjo, both
+		 * shipped with macOS, are turned down for the Apple-specific tables they carry. Passing
+		 * that wording through sends someone who imported a font off their own disk to go and look
+		 * at their connection. The container was already checked before the file was stored, so at
+		 * this point the browser is the one saying no, and it should say so.
+		 */
+		const rejected = typeof cause === "object" && cause !== null && "name" in cause && cause.name === "NetworkError";
+		const detail = rejected ? "浏览器拒绝了这个字体文件（可能用了它不支持的字体表）" : cause instanceof Error ? cause.message : String(cause);
+		throw new Error(`字体“${font.name}”无法加载：${detail}`, { cause });
+	}
+}
+
+/** Load and register one imported face, sharing an in-flight request for the same file. */
+export async function loadImportedFont(font: ImportedFontData): Promise<void> {
+	let pending = loadingFonts.get(font.id);
+	if (!pending) {
+		pending = installFont(font).catch((cause: unknown) => {
+			loadingFonts.delete(font.id);
+			loadedFamilies.delete(font.id);
+			throw cause;
+		});
+		loadingFonts.set(font.id, pending);
+	}
+	await pending;
+}
+
+/** Keep the body override limited to a selected face that the browser has accepted. */
+export function syncImportedUiFont(stack: string): void {
+	const root = document.documentElement.style;
+	if (onPhone()) {
+		root.removeProperty("--ly-imported-ui-font");
+		return;
+	}
+	const id = importedFontId(stack);
+	const family = id ? loadedFamilies.get(id) : undefined;
+	if (family) root.setProperty("--ly-imported-ui-font", `"${family}"`);
+	else root.removeProperty("--ly-imported-ui-font");
+}
+
+/** Read only the imported faces named by the saved UI and code stacks. */
+export async function loadSelectedFonts(uiFont: string, codeFont: string): Promise<void> {
+	const version = ++selectionVersion;
+	syncImportedUiFont(uiFont);
+	if (onPhone()) return;
+
+	const uiId = importedFontId(uiFont);
+	const codeId = importedFontId(codeFont);
+	const errors: unknown[] = [];
+
+	if (uiId) {
+		try {
+			await loadImportedFont(await bridge.fonts.read(uiId));
+		} catch (cause) {
+			errors.push(cause);
+		}
+		if (version === selectionVersion) syncImportedUiFont(uiFont);
+	}
+
+	if (codeId && codeId !== uiId) {
+		try {
+			await loadImportedFont(await bridge.fonts.read(codeId));
+		} catch (cause) {
+			errors.push(cause);
+		}
+	}
+
+	if (errors.length === 1) throw errors[0];
+	if (errors.length > 1) throw new AggregateError(errors, "所选导入字体加载失败");
+}

--- a/packages/desktop/src/features/settings/index.ts
+++ b/packages/desktop/src/features/settings/index.ts
@@ -14,6 +14,7 @@ export { GhostButton, Toggle } from "./controls.tsx";
 export { TextInput, InlineSelect } from "./inputs.tsx";
 export { NumberField, TimeField } from "./pickers.tsx";
 export { applyAppearance, watchSystemTheme } from "./theme.ts";
+export { loadSelectedFonts, syncImportedUiFont } from "./imported-fonts.ts";
 
 /*
  * 顶层视图不在这张表上。

--- a/packages/desktop/src/styles/base.css
+++ b/packages/desktop/src/styles/base.css
@@ -26,8 +26,20 @@
      * beside it, and CJK punctuation fell through to `-apple-system` — which is a western face, so
      * it sets a full-width comma the western way, floating at mid-height instead of sitting at the
      * bottom-left of its box. 「加德克拉斯，123」 with the comma halfway up the line.
+     *
+     * An imported font goes in front of even that, and is the one thing allowed to. Everything
+     * above is about a default nobody chose; this is a file the user went and found. Someone who
+     * imports a Chinese face wants it used for Chinese — leaving `Lyra CJK` in front would apply
+     * their font to the latin half of a line and silently ignore it for the half they picked it
+     * for. `syncImportedUiFont` sets the variable only once the browser has accepted the face, so
+     * a font that fails to load never reaches this line and the CJK adjustment keeps working.
+     *
+     * `Lyra CJK` is then named twice, which costs nothing: when no font is imported the fallback
+     * resolves to the same family already sitting behind it, and when one is imported it is what
+     * catches the CJK an imported latin face does not cover.
      */
-	font-family: var(--ly-script-font, "Lyra CJK"), var(--ly-ui-font, var(--font-sans));
+	font-family: var(--ly-imported-ui-font, var(--ly-script-font, "Lyra CJK")), var(--ly-script-font, "Lyra CJK"),
+	  var(--ly-ui-font, var(--font-sans));
     font-size: var(--ly-ui-size, 13px);
     line-height: 1.6;
     /*

--- a/packages/desktop/test/custom-fonts.test.ts
+++ b/packages/desktop/test/custom-fonts.test.ts
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { copyFile, link, mkdir, mkdtemp, open, readFile, readdir, realpath, rename, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test, type TestContext } from "node:test";
+import { CustomFontStore } from "../electron/custom-fonts.ts";
+import { MAX_FONT_SIZE, validateFont } from "../electron/font-validation.ts";
+import { hasCode } from "../electron/custom-font-files.ts";
+import type { ImportedFont } from "../shared/custom-fonts.ts";
+import { fontFixture } from "./helpers/font-fixtures.ts";
+
+async function fixture(t: TestContext) {
+	const root = await realpath(await mkdtemp(join(tmpdir(), "lyra-custom-fonts-")));
+	t.after(() => rm(root, { recursive: true, force: true }));
+	const userData = join(root, "profile");
+	await mkdir(userData);
+	const store = new CustomFontStore(userData);
+	async function source(name = "Example.ttf", bytes = fontFixture("ttf")) {
+		const path = join(root, name);
+		await writeFile(path, bytes);
+		return path;
+	}
+	return { root, userData, store, source };
+}
+
+async function fileSymlink(t: TestContext, target: string, path: string): Promise<boolean> {
+	try {
+		await symlink(target, path, "file");
+		return true;
+	} catch (error) {
+		if (process.platform !== "win32" || (!hasCode(error, "EPERM") && !hasCode(error, "EACCES"))) throw error;
+		t.skip("File symlinks require Windows developer mode or elevated privileges");
+		return false;
+	}
+}
+
+const formats: ImportedFont["format"][] = ["ttf", "otf", "woff", "woff2"];
+for (const format of formats) {
+	test(`imports ${format}, persists its name and restores list/read after restart`, async (t) => {
+		const { userData, store, source } = await fixture(t);
+		assert.deepEqual(await store.list(), []);
+		const bytes = fontFixture(format);
+		const path = await source(`My font.${format.toUpperCase()}`, bytes);
+		const imported = await store.importFile(path);
+		const id = createHash("sha256").update(bytes).digest("hex");
+		assert.deepEqual(imported, {
+			id, name: "My font", family: `Lyra Imported ${id}`, format, size: bytes.length,
+			data: `data:font/${format};base64,${bytes.toString("base64")}`,
+		});
+		await rm(path);
+		const restarted = new CustomFontStore(userData);
+		assert.deepEqual(await restarted.read(id), imported);
+		assert.deepEqual(await restarted.list(), [{ id, name: imported.name, family: imported.family, format, size: bytes.length }]);
+		assert.deepEqual(await readdir(join(userData, "fonts")), [id]);
+	});
+}
+
+test("content deduplication preserves the first name across instances and concurrent imports", async (t) => {
+	const { userData, store, source } = await fixture(t);
+	const firstPath = await source("First.ttf");
+	const secondPath = await source("Second.ttf");
+	const other = new CustomFontStore(userData);
+	const imported = await Promise.all(Array.from({ length: 12 }, (_, index) =>
+		(index % 2 ? store : other).importFile(index % 2 ? firstPath : secondPath)));
+	for (const font of imported) assert.deepEqual(font, imported[0]);
+	assert.deepEqual(await store.importFile(firstPath), imported[0]);
+	assert.deepEqual(await store.importFile(secondPath), imported[0]);
+	assert.equal((await store.list()).length, 1);
+	assert.deepEqual(await readdir(join(userData, "fonts")), [imported[0].id]);
+});
+
+test("distinct concurrent imports publish complete independent entries", async (t) => {
+	const { store, source } = await fixture(t);
+	const paths = await Promise.all(formats.map((format) => source(`Font.${format}`, fontFixture(format))));
+	const imported = await Promise.all(paths.map((path) => store.importFile(path)));
+	assert.equal((await store.list()).length, formats.length);
+	for (const font of imported) assert.deepEqual(await store.read(font.id), font);
+});
+
+test("rejects empty, oversized, disguised and unsupported files without creating entries", async (t) => {
+	const { store, source } = await fixture(t);
+	const invalid = [
+		await source("Empty.ttf", Buffer.alloc(0)),
+		await source("Text.ttf", Buffer.from("not a font")),
+		await source("Disguised.otf", fontFixture("ttf")),
+		await source("Font.txt", fontFixture("ttf")),
+	];
+	for (const path of invalid) await assert.rejects(store.importFile(path));
+	const large = await source("Large.ttf");
+	const file = await open(large, "r+");
+	try { await file.truncate(MAX_FONT_SIZE + 1); } finally { await file.close(); }
+	await assert.rejects(store.importFile(large), /size/iu);
+	assert.deepEqual(await store.list(), []);
+});
+
+test("accepts exactly 32 MiB and rejects one extra byte", () => {
+	const bytes = Buffer.alloc(MAX_FONT_SIZE);
+	fontFixture("ttf").copy(bytes);
+	assert.equal(validateFont(bytes, "ttf"), "ttf");
+	assert.throws(() => validateFont(Buffer.alloc(MAX_FONT_SIZE + 1), "ttf"), /32 MiB/iu);
+});
+
+test("rejects signature-only headers, missing tables, invalid ranges and bad compression", () => {
+	for (const format of formats) {
+		const bytes = fontFixture(format);
+		assert.throws(() => validateFont(bytes.subarray(0, format === "ttf" || format === "otf" ? 12 : 48), format), /Invalid font/iu);
+		const badSignature = Buffer.from(bytes);
+		badSignature.fill(0, 0, 4);
+		assert.throws(() => validateFont(badSignature, format), /Invalid font/iu);
+	}
+	const missing = fontFixture("ttf");
+	missing.write("xxxx", 12, "ascii");
+	assert.throws(() => validateFont(missing, "ttf"), /Invalid font/iu);
+	const range = fontFixture("ttf");
+	range.writeUInt32BE(0xfffffff0, 20);
+	assert.throws(() => validateFont(range, "ttf"), /Invalid font/iu);
+	const overlap = fontFixture("ttf");
+	overlap.writeUInt32BE(overlap.readUInt32BE(20), 36);
+	assert.throws(() => validateFont(overlap, "ttf"), /Invalid font/iu);
+	const woff = fontFixture("woff");
+	woff.writeUInt32BE(MAX_FONT_SIZE + 1, 56);
+	assert.throws(() => validateFont(woff, "woff"), /Invalid font/iu);
+	const woff2 = fontFixture("woff2");
+	woff2.fill(0xff, 48 + woff2.readUInt16BE(12) * 2);
+	assert.throws(() => validateFont(woff2, "woff2"), /Invalid font/iu);
+});
+
+test("only hash ids are accepted; paths and unknown ids cannot read arbitrary files", async (t) => {
+	const { root, store, source } = await fixture(t);
+	const path = await source();
+	for (const id of ["", "..", "../Example.ttf", path, "a".repeat(63), "A".repeat(64), `a/${"b".repeat(64)}`, "\0"]) {
+		await assert.rejects(store.read(id), /Invalid imported font id/u);
+	}
+	await assert.rejects(store.read("0".repeat(64)), { code: "ENOENT" });
+	await assert.rejects(store.importFile("Example.ttf"), /path/iu);
+	await assert.rejects(store.importFile(root), /regular file/iu);
+});
+
+test("rejects selected file symlinks and hard links", async (t) => {
+	const { root, store, source } = await fixture(t);
+	const original = await source();
+	const linked = join(root, "Linked.ttf");
+	await link(original, linked);
+	await assert.rejects(store.importFile(linked), /regular file/iu);
+	await rm(linked);
+	if (!await fileSymlink(t, original, linked)) return;
+	await assert.rejects(store.importFile(linked), /symbolic links/iu);
+});
+
+test("rejects linked source ancestors and linked storage roots", async (t) => {
+	const { root, userData, store, source } = await fixture(t);
+	const path = await source();
+	const outside = join(root, "outside");
+	await mkdir(outside);
+	await copyFile(path, join(outside, "Example.ttf"));
+	const linked = join(root, "linked");
+	await symlink(outside, linked, process.platform === "win32" ? "junction" : "dir");
+	await assert.rejects(store.importFile(join(linked, "Example.ttf")), /symbolic links/iu);
+	await symlink(outside, join(userData, "fonts"), process.platform === "win32" ? "junction" : "dir");
+	await assert.rejects(store.list(), /Unsafe font directory/u);
+	await assert.rejects(store.importFile(path), /Unsafe font directory/u);
+	assert.deepEqual(await readdir(outside), ["Example.ttf"]);
+});
+
+test("rejects linked stored entries without touching the target", async (t) => {
+	const { root, userData, store, source } = await fixture(t);
+	const font = await store.importFile(await source());
+	const entry = join(userData, "fonts", font.id);
+	const outside = join(root, "moved-entry");
+	await rename(entry, outside);
+	await symlink(outside, entry, process.platform === "win32" ? "junction" : "dir");
+	await assert.rejects(store.read(font.id), /Unsafe font directory/u);
+	await assert.rejects(store.list(), /unsafe/iu);
+	await assert.rejects(store.importFile(await source()), /Unsafe font directory/u);
+	assert.equal((await readFile(join(outside, "font.bin"))).length, font.size);
+});
+
+test("rejects linked stored resources and metadata", async (t) => {
+	const { root, userData, store, source } = await fixture(t);
+	const font = await store.importFile(await source());
+	for (const name of ["font.bin", "metadata.json"]) {
+		const path = join(userData, "fonts", font.id, name);
+		const outside = join(root, name);
+		await rename(path, outside);
+		if (!await fileSymlink(t, outside, path)) return;
+		await assert.rejects(store.read(font.id), /regular file/iu);
+		await rm(path);
+		await rename(outside, path);
+	}
+});
+
+test("rejects damaged metadata and resources instead of silently replacing them", async (t) => {
+	const { userData, store, source } = await fixture(t);
+	const path = await source();
+	const font = await store.importFile(path);
+	const directory = join(userData, "fonts", font.id);
+	const metadataPath = join(directory, "metadata.json");
+	const original = await readFile(metadataPath);
+	await writeFile(metadataPath, JSON.stringify({ ...font, family: "Other family", data: "ignored" }));
+	await assert.rejects(store.read(font.id), /metadata/iu);
+	await assert.rejects(store.importFile(path), /metadata/iu);
+	await writeFile(metadataPath, original);
+	const bytes = fontFixture("ttf");
+	bytes[bytes.length - 1] ^= 1;
+	await writeFile(join(directory, "font.bin"), bytes);
+	await assert.rejects(store.read(font.id), /integrity/iu);
+	await rm(join(directory, "font.bin"));
+	await assert.rejects(store.importFile(path), /incomplete/iu);
+});
+
+test("ignores unpublished transactions after a restart", async (t) => {
+	const { userData, store } = await fixture(t);
+	assert.deepEqual(await store.list(), []);
+	const pending = join(userData, "fonts", ".import-interrupted");
+	await mkdir(pending);
+	await writeFile(join(pending, "font.bin"), fontFixture("ttf"));
+	assert.deepEqual(await new CustomFontStore(userData).list(), []);
+	assert.deepEqual(await readdir(pending), ["font.bin"]);
+});

--- a/packages/desktop/test/helpers/font-fixtures.ts
+++ b/packages/desktop/test/helpers/font-fixtures.ts
@@ -1,0 +1,91 @@
+import { brotliCompressSync, deflateSync } from "node:zlib";
+import type { ImportedFont } from "../../shared/custom-fonts.ts";
+
+/** Minimal containers deliberately do not claim to exercise the browser's outline sanitizer. */
+function tables(otf: boolean): Array<{ tag: string; bytes: Buffer }> {
+	const head = Buffer.alloc(54);
+	head.writeUInt32BE(0x00010000, 0);
+	head.writeUInt32BE(0x5f0f3cf5, 12);
+	head.writeUInt16BE(1000, 18);
+	const maxp = Buffer.alloc(otf ? 6 : 32);
+	maxp.writeUInt32BE(otf ? 0x00005000 : 0x00010000, 0);
+	maxp.writeUInt16BE(1, 4);
+	const cmap = Buffer.alloc(36);
+	cmap.writeUInt16BE(1, 2);
+	cmap.writeUInt16BE(3, 4);
+	cmap.writeUInt16BE(1, 6);
+	cmap.writeUInt32BE(12, 8);
+	cmap.writeUInt16BE(4, 12);
+	cmap.writeUInt16BE(24, 14);
+	cmap.writeUInt16BE(2, 18);
+	cmap.writeUInt16BE(2, 20);
+	cmap.writeUInt16BE(0xffff, 26);
+	cmap.writeUInt16BE(0xffff, 30);
+	cmap.writeUInt16BE(1, 32);
+	const outline = otf
+		? [{ tag: "CFF ", bytes: Buffer.from([1, 0, 4, 1]) }]
+		: [{ tag: "glyf", bytes: Buffer.alloc(10) }, { tag: "loca", bytes: Buffer.from([0, 0, 0, 5]) }];
+	return [...outline, { tag: "cmap", bytes: cmap }, { tag: "head", bytes: head }, { tag: "maxp", bytes: maxp }]
+		.sort((left, right) => left.tag.localeCompare(right.tag));
+}
+
+function pad(size: number): number {
+	return Math.ceil(size / 4) * 4;
+}
+
+export function fontFixture(format: ImportedFont["format"]): Buffer {
+	const entries = tables(format === "otf");
+	const flavor = format === "otf" ? 0x4f54544f : 0x00010000;
+	const sfntSize = 12 + entries.length * 16 + entries.reduce((sum, table) => sum + pad(table.bytes.length), 0);
+	if (format === "ttf" || format === "otf") {
+		const bytes = Buffer.alloc(sfntSize);
+		bytes.writeUInt32BE(flavor, 0);
+		bytes.writeUInt16BE(entries.length, 4);
+		let offset = 12 + entries.length * 16;
+		entries.forEach((table, index) => {
+			const entry = 12 + index * 16;
+			bytes.write(table.tag, entry, "ascii");
+			bytes.writeUInt32BE(offset, entry + 8);
+			bytes.writeUInt32BE(table.bytes.length, entry + 12);
+			table.bytes.copy(bytes, offset);
+			offset += pad(table.bytes.length);
+		});
+		return bytes;
+	}
+	if (format === "woff") {
+		const stored = entries.map((table) => {
+			const compressed = deflateSync(table.bytes);
+			return compressed.length < table.bytes.length ? compressed : table.bytes;
+		});
+		const bytes = Buffer.alloc(44 + entries.length * 20 + stored.reduce((sum, table) => sum + pad(table.length), 0));
+		bytes.write("wOFF", 0, "ascii");
+		bytes.writeUInt32BE(flavor, 4);
+		bytes.writeUInt32BE(bytes.length, 8);
+		bytes.writeUInt16BE(entries.length, 12);
+		bytes.writeUInt32BE(sfntSize, 16);
+		let offset = 44 + entries.length * 20;
+		entries.forEach((table, index) => {
+			const entry = 44 + index * 20;
+			bytes.write(table.tag, entry, "ascii");
+			bytes.writeUInt32BE(offset, entry + 4);
+			bytes.writeUInt32BE(stored[index].length, entry + 8);
+			bytes.writeUInt32BE(table.bytes.length, entry + 12);
+			stored[index].copy(bytes, offset);
+			offset += pad(stored[index].length);
+		});
+		return bytes;
+	}
+	const indices: Record<string, number> = { cmap: 0, head: 1, maxp: 4, glyf: 0xca, loca: 0xcb };
+	const directory = Buffer.from(entries.flatMap((table) => [indices[table.tag], table.bytes.length]));
+	const compressed = brotliCompressSync(Buffer.concat(entries.map((table) => table.bytes)));
+	const bytes = Buffer.alloc(48 + directory.length + compressed.length);
+	bytes.write("wOF2", 0, "ascii");
+	bytes.writeUInt32BE(flavor, 4);
+	bytes.writeUInt32BE(bytes.length, 8);
+	bytes.writeUInt16BE(entries.length, 12);
+	bytes.writeUInt32BE(sfntSize, 16);
+	bytes.writeUInt32BE(compressed.length, 20);
+	directory.copy(bytes, 48);
+	compressed.copy(bytes, 48 + directory.length);
+	return bytes;
+}

--- a/packages/desktop/test/ui/imported-font-loader.test.ts
+++ b/packages/desktop/test/ui/imported-font-loader.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { test, type TestContext } from "node:test";
+import type { ImportedFontData } from "../../shared/custom-fonts.ts";
+import {
+	importedUiFontStack,
+	loadImportedFont,
+	loadSelectedFonts,
+} from "../../src/features/settings/imported-fonts.ts";
+
+function font(hex: string, name = "Test Sans"): ImportedFontData {
+	const id = hex.repeat(64);
+	return {
+		id,
+		name,
+		family: `Lyra Imported ${id}`,
+		format: "woff2",
+		size: 2048,
+		data: "data:font/woff2;base64,d09GMg==",
+	};
+}
+
+function stubFontFace(t: TestContext, shouldFail: () => boolean) {
+	const previousFace = Object.getOwnPropertyDescriptor(globalThis, "FontFace");
+	const previousFonts = Object.getOwnPropertyDescriptor(document, "fonts");
+	let loads = 0;
+	let adds = 0;
+
+	class TestFontFace {
+		status = "unloaded";
+
+		async load() {
+			loads++;
+			if (shouldFail()) throw new Error("browser rejected font");
+			this.status = "loaded";
+			return this;
+		}
+	}
+
+	Object.defineProperty(globalThis, "FontFace", { configurable: true, value: TestFontFace });
+	Object.defineProperty(document, "fonts", {
+		configurable: true,
+		value: { add: () => { adds++; } },
+	});
+	t.after(() => {
+		if (previousFace) Object.defineProperty(globalThis, "FontFace", previousFace);
+		else Reflect.deleteProperty(globalThis, "FontFace");
+		if (previousFonts) Object.defineProperty(document, "fonts", previousFonts);
+		else Reflect.deleteProperty(document, "fonts");
+	});
+	return { loads: () => loads, adds: () => adds };
+}
+
+function stubFontsBridge(t: TestContext, host: "desktop" | "mobile", read: (id: string) => Promise<ImportedFontData>) {
+	const previous = Object.getOwnPropertyDescriptor(window, "lyra");
+	Object.defineProperty(window, "lyra", {
+		configurable: true,
+		value: { host, fonts: { read } },
+	});
+	t.after(() => {
+		if (previous) Object.defineProperty(window, "lyra", previous);
+		else Reflect.deleteProperty(window, "lyra");
+	});
+}
+
+test("a saved imported selection is read and registered again on startup", async (t) => {
+	const selected = font("a", "Restart Sans");
+	const reads: string[] = [];
+	const faces = stubFontFace(t, () => false);
+	stubFontsBridge(t, "desktop", async (id) => {
+		reads.push(id);
+		return selected;
+	});
+
+	await loadSelectedFonts(importedUiFontStack(selected.family), "ui-monospace, monospace");
+
+	assert.deepEqual(reads, [selected.id]);
+	assert.equal(faces.loads(), 1);
+	assert.equal(faces.adds(), 1);
+	assert.equal(document.documentElement.style.getPropertyValue("--ly-imported-ui-font"), `"${selected.family}"`);
+});
+
+test("the phone path never reaches the local fonts bridge", async (t) => {
+	let reads = 0;
+	stubFontsBridge(t, "mobile", async () => {
+		reads++;
+		return font("b");
+	});
+
+	await loadSelectedFonts(importedUiFontStack(font("b").family), importedUiFontStack(font("b").family));
+
+	assert.equal(reads, 0);
+	assert.equal(document.documentElement.style.getPropertyValue("--ly-imported-ui-font"), "");
+});
+
+test("a rejected face surfaces the browser error and can be retried", async (t) => {
+	const selected = font("c", "Broken Sans");
+	let failing = true;
+	const faces = stubFontFace(t, () => failing);
+
+	await assert.rejects(loadImportedFont(selected), /Broken Sans.*browser rejected font/u);
+	failing = false;
+	await loadImportedFont(selected);
+
+	assert.equal(faces.loads(), 2);
+	assert.equal(faces.adds(), 1);
+});
+
+test("concurrent requests for one imported file share one FontFace load", async (t) => {
+	const selected = font("d", "Concurrent Sans");
+	const faces = stubFontFace(t, () => false);
+
+	await Promise.all([loadImportedFont(selected), loadImportedFont(selected)]);
+
+	assert.equal(faces.loads(), 1);
+	assert.equal(faces.adds(), 1);
+});

--- a/packages/desktop/test/ui/imported-font-settings.test.ts
+++ b/packages/desktop/test/ui/imported-font-settings.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { test, type TestContext } from "node:test";
+import { act, createElement as h } from "react";
+import { DEFAULT_SETTINGS, type Settings } from "@lyra/core";
+import type { ImportedFont, ImportedFontData } from "../../shared/custom-fonts.ts";
+import { ImportedFontsSettings } from "../../src/features/settings/ImportedFontsSettings.tsx";
+import {
+	DEFAULT_UI_FONT_STACK,
+	importedUiFontStack,
+} from "../../src/features/settings/imported-fonts.ts";
+import { CODE_DEFAULTS } from "../../src/features/settings/code-defaults.ts";
+import { useApp } from "../../src/store/index.ts";
+import { click, mount, type Mounted } from "../helpers/mount.ts";
+
+function font(hex: string, name = "Preview Sans"): ImportedFontData {
+	const id = hex.repeat(64);
+	return {
+		id,
+		name,
+		family: `Lyra Imported ${id}`,
+		format: "otf",
+		size: 4096,
+		data: "data:font/otf;base64,T1RUTw==",
+	};
+}
+
+function stubStore(t: TestContext, settings: Settings) {
+	const previous = useApp.getState();
+	const saved: Settings[] = [];
+	useApp.setState({
+		settings,
+		saveSettings: async (next) => {
+			saved.push(next);
+			useApp.setState({ settings: next });
+		},
+	});
+	t.after(() => useApp.setState({
+		settings: previous.settings,
+		saveSettings: previous.saveSettings,
+		notices: previous.notices,
+	}));
+	return saved;
+}
+
+function stubBridge(
+	t: TestContext,
+	options: {
+		list?: () => Promise<ImportedFont[]>;
+		importFont?: () => Promise<ImportedFontData | null>;
+		read?: (id: string) => Promise<ImportedFontData>;
+	},
+) {
+	const previous = Object.getOwnPropertyDescriptor(window, "lyra");
+	Object.defineProperty(window, "lyra", {
+		configurable: true,
+		value: {
+			host: "desktop",
+			fonts: {
+				list: options.list ?? (async () => []),
+				import: options.importFont ?? (async () => null),
+				read: options.read ?? (async () => { throw new Error("unexpected font read"); }),
+			},
+		},
+	});
+	t.after(() => {
+		if (previous) Object.defineProperty(window, "lyra", previous);
+		else Reflect.deleteProperty(window, "lyra");
+	});
+}
+
+function rejectFontFaces(t: TestContext) {
+	const previous = Object.getOwnPropertyDescriptor(globalThis, "FontFace");
+	class RejectedFontFace {
+		async load() {
+			throw new Error("invalid outlines");
+		}
+	}
+	Object.defineProperty(globalThis, "FontFace", { configurable: true, value: RejectedFontFace });
+	t.after(() => {
+		if (previous) Object.defineProperty(globalThis, "FontFace", previous);
+		else Reflect.deleteProperty(globalThis, "FontFace");
+	});
+}
+
+async function settle() {
+	await act(async () => {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	});
+}
+
+function button(view: Mounted, label: string): HTMLButtonElement {
+	const found = view.all<HTMLButtonElement>("button").find((candidate) => candidate.textContent?.includes(label));
+	assert.ok(found, `no button containing ${label}`);
+	return found;
+}
+
+test("cancelling the native picker leaves the current font selection unchanged", async (t) => {
+	const saved = stubStore(t, DEFAULT_SETTINGS);
+	let imports = 0;
+	stubBridge(t, {
+		importFont: async () => {
+			imports++;
+			return null;
+		},
+	});
+	const view = await mount(h(ImportedFontsSettings));
+	t.after(() => view.unmount());
+	await settle();
+
+	await click(button(view, "导入字体"));
+	await settle();
+
+	assert.equal(imports, 1);
+	assert.equal(saved.length, 0);
+	assert.equal(view.all('[role="alert"]').length, 0);
+});
+
+test("a browser font rejection is visible and never changes settings", async (t) => {
+	const broken = font("e", "Broken Preview");
+	const saved = stubStore(t, DEFAULT_SETTINGS);
+	stubBridge(t, { importFont: async () => broken });
+	rejectFontFaces(t);
+	const view = await mount(h(ImportedFontsSettings));
+	t.after(() => view.unmount());
+	await settle();
+
+	await click(button(view, "导入字体"));
+	await settle();
+
+	assert.match(view.find('[role="alert"]').textContent ?? "", /字体导入失败.*invalid outlines/u);
+	assert.equal(saved.length, 0);
+	assert.equal(button(view, "应用为 UI 字体").disabled, true);
+});
+
+test("restore defaults changes only the two font stacks", async (t) => {
+	const selected = font("f", "Reset Sans");
+	const settings: Settings = {
+		...DEFAULT_SETTINGS,
+		appearance: {
+			...DEFAULT_SETTINGS.appearance,
+			theme: "light",
+			accent: "#FF3366",
+			uiFont: importedUiFontStack(selected.family),
+			codeFont: `"${selected.family}", monospace`,
+		},
+	};
+	const saved = stubStore(t, settings);
+	stubBridge(t, { list: async () => [selected] });
+	const view = await mount(h(ImportedFontsSettings));
+	t.after(() => view.unmount());
+	await settle();
+
+	await click(button(view, "只恢复默认字体"));
+	await settle();
+
+	assert.equal(saved.length, 1);
+	assert.equal(saved[0]?.appearance.uiFont, DEFAULT_UI_FONT_STACK);
+	assert.equal(saved[0]?.appearance.codeFont, CODE_DEFAULTS.codeFont);
+	assert.equal(saved[0]?.appearance.theme, "light");
+	assert.equal(saved[0]?.appearance.accent, "#FF3366");
+});


### PR DESCRIPTION
外观设置里加一个「导入字体」：走原生选择框挑一个本机 ttf/otf/woff/woff2，用作界面字体或代码字体——**包括中文字形**，这是它和现有那几个预置选项的关键差别。

## 为什么

预置字体的中文是靠 `local()` 借系统字体，不同机器上长得不一样。想用自己那一款中文字体的人，之前没有任何入口。

## 六个设计决定

完整理由在 [ADR-0021](docs/adr/0021-imported-fonts-never-leave-this-machine.md)，这里是摘要。

**1. 路径不过 IPC，只认原生选择框。** `fonts.import` 不接受参数——渲染进程说不出「打开哪个文件」，只能说「让用户挑一个」。于是「渲染进程被攻破之后能读到哪些文件」的答案是：一个都读不到。契约测试读 `ipc/fonts.ts` 的源码把这条钉住：handler 存在、`properties: ["openFile"]` 不允许多选、取消返回 `null`。

`fonts.read` 确实收一个参数，但那是 64 位十六进制的内容哈希，正则挡在最前面，不是路径。

**2. 三个方法都 `remote: false`。** 手机通过配对令牌连上来的是一个会话，不是这台电脑的文件系统访问权。代价是手机上取不到导入的字体：`settings.json` 会同步过去，手机拿到一个它取不到的 family，靠字体栈后面的 `PingFang SC` 兜底。这是降级，不是坏掉。

**3. 按内容寻址，用目录 rename 提交。** 存 `userData/fonts/<sha256>/`，内含 `font.bin` 和 `metadata.json`。同一文件导两次是同一条目；先写临时目录再 `rename`，所以中断的导入是不可见的，而不是一个只写了一半的条目。读回时重算哈希与目录名比对。

**4. 送进渲染进程的是 `data:` URL，不是文件路径。** 给路径就要开 `file://` 或再造一个自定义协议，两条都在扩大渲染进程能碰到的东西；而字体本来就要整个读进内存，省不出流式的好处。

**5. 容器校验放在存之前，但浏览器才是最后一关。** `font-validation.ts` 检查签名与扩展名一致、表目录不越界不重叠、必需表齐全、WOFF2 的 brotli 流能解开且有界。它不是字形消毒器，`loadImportedFont` 仍要 `await FontFace.load()`。

**6. 导入的字体排在 `Lyra CJK` 之前。**

```css
font-family: var(--ly-imported-ui-font, var(--ly-script-font, "Lyra CJK")), var(--ly-script-font, "Lyra CJK"),
  var(--ly-ui-font, var(--font-sans));
```

`Lyra CJK` 排在配置字体前面本来是对的——它管中文的字号匹配和全角标点的位置——但那是「用户没选过」时的默认。一个人专门找了个中文字体导进来，就是想让中文用它；把 `Lyra CJK` 留在前面，等于把他挑的字体用在这一行的英文上、对他真正在意的那一半视而不见。

`syncImportedUiFont` 只在浏览器**已经接受**这个 face 之后才设 `--ly-imported-ui-font`，所以加载失败的字体到不了这一行，CJK 那层调整照常生效。`Lyra CJK` 在栈里出现两次是刻意的：没导入字体时 `var()` 兜底解析成它自己，多一个同名条目不产生代价；导入了字体时，它接住导入字体没覆盖到的 CJK 字形。

## 一次导入走过的路

```
用户点「导入字体」
  └─ fonts:import ──► 主进程弹原生 showOpenDialog（渲染进程不传路径）
       └─ custom-font-files.ts   拒符号链接、硬链接、读取中被换掉的文件
       └─ font-validation.ts     签名 vs 扩展名、表目录、必需表、WOFF2 有界解压
       └─ custom-fonts.ts        sha256 → 写临时目录 → rename 提交
  ◄── 返回 data:font/...;base64（不含任何本机路径）
       └─ imported-fonts.ts      new FontFace(...) → await load() → document.fonts.add()
            └─ 加载成功后才设 --ly-imported-ui-font
                 └─ base.css     该变量排在 Lyra CJK 之前 ──► 屏幕换字体
```

## 改动构成

新增 13 个文件、修改 10 个。修改的那 10 个全是接线，加起来 55 行。

| 层 | 文件 | 行数 |
| --- | --- | --- |
| 契约 | `contract/src/methods.ts` | +5 |
| 主进程 | `electron/font-validation.ts` | 245（新） |
| | `electron/custom-fonts.ts` | 139（新） |
| | `electron/custom-font-files.ts` | 71（新） |
| | `electron/ipc/fonts.ts` | 19（新） |
| 共享类型 | `shared/custom-fonts.ts` | 13（新） |
| 渲染进程 | `settings/ImportedFontsSettings.tsx` | 220（新） |
| | `settings/imported-fonts.ts` | 102（新） |
| | `styles/base.css` | +14/-2 |
| 接线 | `main.ts` / `App.tsx` / `AppearanceSettings.tsx` / `index.ts` / `ipc-types.ts` | 共 +24 |
| 测试 | 4 个文件，24 条用例 | 588（新） |
| 验证 | `e2e/imported-font-probe.ts` | 201（新） |
| 文档 | ADR-0021 + 两处索引/正文 | 114 |

`preload.ts` 不需要改：它遍历 `METHODS` 生成 invoke 方法。

## 验证

`lint` / `stylelint` / 六个包 `typecheck` / `arch` / 链接检查全过。测试：desktop 1609 + UI 346、contract 21、core 1366、mobile 83、agent-cli 7、registry-shared 27、relay 17、root 2。

### 真实应用里量到的数

`e2e/imported-font-probe.ts` 把每段文字画进 canvas 再哈希像素。宽度单独不够用——CJK 字形在哪个字体里都是全角，两个完全不同的字体量出来一样宽，只有画出来才分得开。

导入 22.2 MiB 的 `Arial Unicode.ttf`：

| 样本 | 实际绘制 | 只用导入字体 | 没有导入字体 |
| --- | --- | --- | --- |
| `Lyra Imported AaBb 123` | `d076db0c` / 607.03px | `d076db0c` / 607.03px | `95f7d262` / 627.87px |
| `中文测试` | `bf6ff6fc` / 224px | `bf6ff6fc` / 224px | `9c0309c4` / 232.96px |
| `，、。` | `d09887b` / 168px | `d09887b` / 168px | `21c9891e` / 116.48px |

汉字那一行就是第 6 条决定买到的东西。经真实 `settings.save` 恢复默认后，字体栈里不再有导入的 family，汉字回到 232.96px。

### 校验器对真实字体的表现

本机 241 个系统字体跑下来接受 240 个，拒绝 1 个：`NISC18030.ttf`，它用 `bhed`/`bdat`/`bloc` 代替 `head`/`glyf`/`loca`，是 Apple 的位图字体。

反过来 **Chromium 拒的比校验器多**：macOS 自带的 `AppleGothic` 和 `AppleMyungjo` 都过不了它的消毒器（`Invalid font data in ArrayBuffer`），因为带 Apple 私有字体表。而 Chromium 对 `data:` URL 的说法是 `A network error occurred`——一个本地文件不可能有网络错误，所以那条单独译成「浏览器拒绝了这个字体文件」，否则用户会去查网络。

这一条是踩出来的：probe 第一版挑了 `AppleGothic` 当样本，跑出来 `--ly-imported-ui-font` 死活不设，查到最后是浏览器拒收，不是任何一处代码写错。

## 已知取舍

- **代码字体不对称。** 「应用为代码字体」写进 `--ly-code-font`，而 `markdown.css` 里 `Lyra CJK` 仍排在它前面，所以导入的等宽字体管拉丁字母，代码块里的中文仍由 `Lyra CJK` 绘制。有意为之：代码绝大多数是拉丁字母，而 `Lyra CJK` 的字号匹配对代码块里偶尔出现的中文反而更合适。要改就是加一个 `--ly-imported-code-font`，按 UI 那条的样子走。
- **只在 macOS 验过**，Windows / Linux 没跑。
- **手机端降级路径**（`uiFont` 同步过去但字体取不到）写进了 ADR，没测。
- `DEFAULT_UI_FONT_STACK` 在 `imported-fonts.ts`、`AppearanceSettings.tsx`、`core/src/config/settings.ts` 三处重复，会漂。渲染进程不能从 core 根入口导入值，所以不能简单合并；单独处理。

## 审阅时值得多看两眼的

1. `custom-font-files.ts` 的 TOCTOU 复检（dev/ino/mtime/nlink）是否有遗漏的窗口。
2. `font-validation.ts` 里 WOFF2 的 UIntBase128 解析和 `transformed` 判定——glyf/loca 的 null transform 是版本 3，其余表是 0，读错了会把目录游标带偏。
3. `base.css` 里 `Lyra CJK` 出现两次是刻意的，不是手滑。

## 与本 PR 无关的既有失败

`core/test/login-path.test.ts` 的「兜底 PATH 找得到 node」在我的机器上红：node 装在 nvm 的版本目录里，硬编码的兜底清单认不出。本分支未改动 `packages/core`，该失败先于本分支存在。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
